### PR TITLE
Update tap3.md

### DIFF
--- a/tap3.md
+++ b/tap3.md
@@ -5,7 +5,7 @@
 * Author: Trishank Karthik Kuppusamy, Sebastien Awwad, Evan Cordell,
           Vladimir Diaz, Jake Moshenko, Justin Cappos
 * Status: Accepted
-* Content-Type: <text/markdown>
+* Content-Type: text/markdown
 * Created: 16-Sep-2016
 
 # Abstract


### PR DESCRIPTION
The `text/markdown` entry for `Content-Type` is surrounded by less-than and greater-than symbols.  The symbols are causing `text/markdown` to not appear in the formatted document.