### PR TITLE
Move the download bits from TAP 4 to TAP 5.

### DIFF
--- a/tap4.md
+++ b/tap4.md
@@ -1,7 +1,7 @@
 * TAP: 4
 * Title: The map file
 * Version: 1
-* Last-Modified: 14-Dec-2016
+* Last-Modified: 29-Dec-2016
 * Author: Trishank Karthik Kuppusamy, Sebastien Awwad, Evan Cordell,
           Vladimir Diaz, Jake Moshenko, Justin Cappos
 * Status: Draft
@@ -14,13 +14,15 @@
 TAP 4 describes how users may specify that a certain repository should be used
 for some targets, while other repositories should be used for other targets.
 In other words, this TAP allows users to _map_ target names to repositories in a
-manner similar to how targets with specific names can be delegated to different roles.
-This allows users to say that a target with a specific type of name (such as 
-django\* or \*.tar.gz) may be found on a specific repository.  Each repository
-has its own root of trust (root role, etc.) so a compromise of one repository
-does not impact other repositories.  This TAP also discusses how the AND relation can
-be extended to multiple repositories to have multiple different repositories with 
-separate roots of trust need to sign off on the same target before installation.
+manner similar to how targets with specific names can be delegated to different
+roles.
+This allows users to say that a target with a specific type of name (such
+as ```django\*``` or ```\*.tar.gz```) may be found on a specific repository.
+Each repository has its own root of trust (root role, etc.) so a compromise of
+one repository does not impact other repositories.
+This TAP also discusses how the AND relation can be extended to multiple
+repositories to have multiple different repositories with separate roots of
+trust need to sign off on the same target before installation.
 
 # Motivation
 
@@ -28,10 +30,11 @@ TAP 4 has been motivated by the following use cases.
 
 ## Use case 1: obtaining different targets from different repositories
 
-Itmay be desirable to use the same instance of TUF to download and verify different
-targets hosted on different repositories (for example, some Python packages from
-their maintainers, while getting other Python packages from PyPI).  In this way,
-one can securely get all Python packages regardless of where they are hosted.
+It may be desirable to use the same instance of TUF to download and verify
+different targets hosted on different repositories (for example, some Python
+packages from their maintainers, while getting other Python packages from PyPI).
+In this way, one can securely get all Python packages regardless of where they
+are hosted.
 There are significant advantages in using the same instance of TUF to manage
 metadata across different repositories, including benefiting from security
 updates, and performance enhancements.
@@ -49,15 +52,15 @@ other targets on the public repository.
 
 ## Use case 3: improving compromise-resilience
 
-To improve compromise-resilience, a user wish to have multiple repositories, each
-with a different root of trust, to sign targets.
+To improve compromise-resilience, a user may wish to have multiple repositories,
+each with a different root of trust, to sign targets.
 The effect is similar to the AND relation used in
 [multi-role delegations](tap3.md).
 However, in multi-role delegations, multiple roles would share the _same_ root
 of trust, even though they must sign the same hashes and length of targets.
 The problem is that, if attackers have compromised a common ancestor of these
-multiple roles (e.g., the top-level targets role or root role), then the security 
-benefits of using multi-role delegations are lost.
+multiple roles (e.g., the top-level targets role or root role), then the
+security benefits of using multi-role delegations are lost.
 The difference in this use case is that multiple roles with _different_
 roots of trust must sign the same hashes and length of desired targets.
 This is done so that the compromise of even the root role of a single repository
@@ -85,10 +88,12 @@ Where these directories are kept is up to the client.
 ## The map file
 
 The map file maps targets to repositories.
-This file is not intended to be automatically available / refreshed from a repository.
-The map file is either constructed by the user using the TUF command-line tools, or
-distributed by an out-of-band bootstrap process.  The file is kept on the client
-and is only modified by a user who is trusted to configure the TUF instance.
+This file is not intended to be automatically available / refreshed from a
+repository.
+The map file is either constructed by the user using the TUF command-line tools,
+or distributed by an out-of-band bootstrap process.
+The file is kept on the client and is only modified by a user who is trusted to
+configure the TUF instance.
 
 The map file contains a dictionary that holds two keys, "repositories" and
 "mapping."
@@ -102,17 +107,12 @@ TUF client where metadata files would be cached.
 Crucially, there is where the [root metadata file](tap5.md) for a repository
 would be found.
 
-There is also a list of URLs that indicates where to retrieve files from or, 
-if omitted, states that files should not be updated.  If present the list of 
-URLs specifies where TUF clients may download metadata and target files.
-Each URL points to a [directory containing metadata and target files](#metadata-and-targets-layout-on-repositories).
-_If this list is empty, then it means that the metadata for the 
-repository will not be updated and that only the files currently on disk
-will be used._
-These files would be updated following the steps detailed in
-[this section](#downloading-metadata-and-target-files).
+There is also a list of URLs that indicates where to retrieve files from.
+This list of URLs should not be omitted or empty, because it specifies where TUF
+clients may download metadata and target files.
+Each URL points to a root directory containing metadata and target files.
 
-The value of the "mapping" key is a priority-ordered list that maps paths (i.e., 
+The value of the "mapping" key is a priority-ordered list that maps paths (i.e.,
 target names) to the specific repositories.
 Every member in this list is a dictionary with at least two keys:
 
@@ -140,7 +140,7 @@ The following is an example of a map file:
       // Much like target delegation, the order of these entries indicates
       // the priority of the delegation.  The entries listed first will be
       // considered first.
-      
+
       // Map any target matching *Django* to both Django and PyPI.
       "paths":        ["*django*"],
       "repositories": ["Django", "PyPI"],
@@ -160,126 +160,6 @@ The following is an example of a map file:
   ]
 }
 ```
-
-## Metadata and targets layout on repositories
-
-In order for TUF clients to download metadata and target files in a uniform way
-across repositories, a repository would organize the files as follows.
-
-All metadata files would be stored under the "metadata" directory.
-This directory would contain at least four files, one for each top-level role:
-root.json, timestamp.json, snapshot.json, and targets.json.
-This directory may also contain a "delegations" subdirectory, which would hold
-only the metadata files for all delegated targets roles.
-Separating the metadata files for the top-level roles from all delegated
-targets roles prevents a delegated targets role from accidentally overwriting
-the metadata file for a top-level role.
-It is up to the repository to enforce that every delegated targets role uses a
-unique name.
-
-All targets files would be stored under the "targets" directory.   
-Beyond this, the repository may organize target files into any hierarchy it
-requires.
-
-The following directory layout may apply to the PyPI repository from the example
-map file:
-
-```
--metadata
--└── root.json
--└── timestamp.json
--└── snapshot.json
--└── targets.json            // signed by the top-level targets role
--    └── delegations
--        ├── Django.json     // signed by the Django delegated targets role
--        ├── Flask.json
--        ├── NumPy.json
--targets
-```
-
-## Metadata and targets layout on clients
-
-On a TUF client, all metadata files would be stored under the "metadata"
-directory.
-This directory would contain the map file, as well as a subdirectory for every
-repository specified in the map file.
-Each repository metadata subdirectory would use the repository name.
-In turn, it would contain two subdirectories: "previous" for the previous set of
-metadata files, and "current" for the current set.
-
-All targets files would be stored under the "targets" directory.
-Targets downloaded from any repository would be written to this directory.
-
-The following directory layout would apply to the example map file:
-
-```
--metadata
--└── map.json           // the map file
--└── Django             // repository name
--    └── current
--        ├── root.json  // minimum requirement
--        └── timestamp.json
--        ├── snapshot.json
--        ├── targets.json
--        └── ...        // see layout of targets delegations on repository
--    └── previous
--└── PyPI/current
--└── PyPI/previous
--targets
-```
-
-## Downloading metadata and target files
-
-A TUF client would perform the following six steps while searching for a target
-on a repository.
-
-First, the client loads the latest downloaded [root metadata file](tap5.md), and
-ensures that: (1) that it has been signed by a threshold of keys, and (2) it has
-not expired.   Recall that the URL field may either contain the location to 
-update the files, or may be empty to say that the repository metadata should not
-be updated.  We will now explicitly explain the procedure for doing this.
-Next, the client tries to update the root metadata file.
-Let M denote the list of URLs associated with this repository in the map file,
-and R denote the list of URLs associated with this top-level role (in this case,
-the root role) in the root metadata file.   
-There are four cases:
-
-1. If R is empty, then this metadata file shall not be updated.
-2. If R is not empty, then this metadata file shall be downloaded in order from
-each URL in R until it is found. If the file could not be found or verified
-using all URLs, then report that it is missing.
-3. If R has been omitted, and M is empty, then this metadata file shall not be
-updated.
-4. If R has been omitted, and M is not empty, then this metadata file shall be
-downloaded in order from each URL in M until it is found. If the file could not
-be found or verified using all URLs, then report that it is missing.
-
-Second, the client uses similar steps to update the timestamp metadata file.
-
-Third, the client uses similar steps to update the snapshot metadata file.
-
-Fourth, the client uses similar steps to update the top-level targets metadata
-file.
-If R is not empty, then the client should be careful in interpreting the entries
-of the snapshot metadata file.
-Suppose that R is
-["https://pypi.python.org/metadata/delegations/Django.json", "http://example.com/path/to/foo.json"].
-First, the client would look up the version number for "Django.json", instead of
-"targets.json" (for the original top-level targets role), in the
-snapshot metadata.
-Then, the client would try to find the desired target using the "Django.json"
-role.
-If the target could not be found or verified, then the client would try to find
-the target using the "foo.json" role, being careful to first look up the version
-number for "foo.json" in the snapshot metadata.
-
-Fifth, the client uses only M to update delegated targets metadata files.
-Each file is downloaded in order from each URL in M until it is found.
-If the file could not be found or verified using all URLs, then report that it
-is missing.
-
-Sixth, the client uses a step similar to the previous step to download all
-target files.
 
 ## Interpreting the map file
 
@@ -312,13 +192,16 @@ the same targets metadata (i.e., length and hashes).
 
 # Backwards Compatibility
 
-This specification is not backwards-compatible because it requires:
+This specification is backwards-compatible, because older clients need not be
+modified in order to recognize a map file.
+Older clients may continue to use a single repository.
+New clients need to add relatively little code to interpret the map file.
+New clients simply need to be careful to store the metadata for each repository
+separately from other repositories (e.g., by using a different directory for
+each repository).
 
-1. TUF clients to support additional, optional fields in the [root metadata file](tap5.md).
-2. A repository to use a [specific filesystem layout](#metadata-and-targets-layout-on-repositories).
-3. A client to use a [map file](#the-map-file).
-4. A client to use a [specific filesystem layout](#metadata-and-targets-layout-on-clients).
-5. A client to [download metadata and target files from a repository in a specific manner](#downloading-metadata-and-target-files).
+An existing repository needs not change how it already stores metadata and
+targets using the TUF specification prior to this TAP.
 
 # Augmented Reference Implementation
 


### PR DESCRIPTION
Remove restrictions of how files are kept on repositories and clients.

Remove restriction on the file names of delegated targets roles in the
snapshot metadata. This came up in a meeting where it was thought that
the top-level targets role, and all delegated targets roles, should be
listed as if they were in the same directory, in order to prevent
delegated targets roles from accidentally overwriting top-level roles.

Since these restrictions were lifted, backwards compatibility looks
quite good.