### PR TITLE
Add additional use case

### DIFF
--- a/tap4.md
+++ b/tap4.md
@@ -49,7 +49,19 @@ In order to use both the private and public repositories, TUF clients need to be
 informed how to search for some targets on the private repository, and all
 other targets on the public repository.
 
-## Use case 3: improving compromise-resilience given multiple repositories
+## Use case 3: verifying the same target against different repositories
+
+[TAP3](tap3.md) allows metadata publishers to require multiple roles to sign
+off on targets, which forces clients to verify against all roles listed by
+the metadata. While this is desirable in some instances, in others it's more
+desirable to allow clients to choose which roles to care about. For example, a
+CI system may only care about developer signatures, while a staging environment
+may wish to verify both developer and CI signatures.
+In order to support this, TUF clients need to be able to require valid
+signatures from multiple repositories, each representing an interested signing
+group.
+
+## Use case 4: improving compromise-resilience given multiple repositories
 
 To improve compromise-resilience, a user may wish to have multiple repositories,
 each with a different root of trust, sign targets.
@@ -70,8 +82,8 @@ targets files.
 However, if repository A's root role or its top level targets role were to be
 compromised, all users can be given malicious targets files, even if repository
 B is not compromised.
-We wish to remedy this case by delegating from the map file so that if either of
-the two repositories is compromised, the users are not at risk.
+We wish to remedy this case by requiring valid signatures from two repositories,
+so that if either of the two repositories is compromised, users are not at risk.
 
 # Rationale
 


### PR DESCRIPTION
Also modified one of the other use case to remove mention of the map file, which hasn't been introduced yet at that point.

I could see how use case 3/4 could be combined, but I kind of like explicitly calling out where you want to check against multiple repositories for organizational reasons rather than compromise resilience. 