### PR TITLE
TAP 7: Add return code rationale

### DIFF
--- a/tap7.md
+++ b/tap7.md
@@ -488,6 +488,17 @@ is available, and an [example is available below](#example-wrapper) as well.
 
 
 A skeleton that can be filled in by implementers is provided
+Note that the Tester will only expect a matching success-or-failure code from
+`update_client` instead of the correct code from a long a list of specific
+error codes (expired metadata, bad signature, replay attack, fewer than the
+threshold number of signatures, etc.) in order to simplify work for Updater
+implementers. This will entail more test and control cases, but should make it
+easier for implementers to use the Conformance Tester without having to make
+substantial changes to Updaters or having to too much extra work in writing
+Wrapper functions.
+
+
+A code skeleton that can be filled in by implementers is provided
 [here](tap7_resources/tap7_wrapper_skeleton.py).
 Also see [Example Wrapper](#example-wrapper) below for a functioning example of
 the Wrapper module - in this case, a Wrapper enabling the Conformance Tester to

--- a/tap7.md
+++ b/tap7.md
@@ -465,44 +465,18 @@ is available, and an [example is available below](#example-wrapper) as well.
 
         ```
 
-        <!---
-        # TODO: Consider additional return fields:
-          hash: (Verdict: No, for now)
-            the hash of the target file installed if there was a target file
-            validated and "installed" (to be tested against the expected
-            fileinfo). This may allow us to make sure that the success was real
-            / the right target was actually chosen.
-            This is probably not necessary, but it's food for thought as we
-            write tests.
-
-          metadata versions: (Verdict: No)
-            a dictionary mapping metadata filename to the version validated in
-            this update. The purpose of this is to allow for an easier time
-            writing the Tester, since it spares us the complication of making
-            the test go so far as to validate a particular target in a large
-            number of sub-tests when all we want to do is determine that e.g.
-            replayed metadata is rejected. Tests are just more complicated to
-            construct sometimes otherwise. Not a good enough reason, IMO;
-            simplicity for the external implementer is paramount.
-        --->
-
-
-A skeleton that can be filled in by implementers is provided
 Note that the Tester will only expect a matching success-or-failure code from
 `update_client` instead of the correct code from a long a list of specific
 error codes (expired metadata, bad signature, replay attack, fewer than the
 threshold number of signatures, etc.) in order to simplify work for Updater
 implementers. This will entail more test and control cases, but should make it
-easier for implementers to use the Conformance Tester without having to make
-substantial changes to Updaters or having to too much extra work in writing
-Wrapper functions.
+easier for implementers to use the Conformance Tester without substantial
+changes to Updaters or too much extra work writing Wrapper functions.
 
 
 A code skeleton that can be filled in by implementers is provided
 [here](tap7_resources/tap7_wrapper_skeleton.py).
-Also see [Example Wrapper](#example-wrapper) below for a functioning example of
-the Wrapper module - in this case, a Wrapper enabling the Conformance Tester to
-test the pre-TAP4 TUF Reference Implementation.
+Also see [Example Wrapper](#example-wrapper) below.
 
 
 ### Example Wrapper


### PR DESCRIPTION
I added a very brief blurb in the TAP on why we're going with two expected return values (from the Wrapper's `updateinstead of many. Here's more of my thinking, for reference. Also caught in this PR are two minor cleaning edits in commit e5c9921.

**Argument 1: We don't need specific error codes.**
I can't think of a case where we actually need specific error codes to test behavior. We're testing updaters, so we can always ask the question "Did it update without manipulation X and not update with manipulation X?"

**Argument 2: Many error codes may be onerous.**
To demand that an updater issue distinct errors that percolate up through the code may be an onerous requirement on an implementer, and we want people to not hesitate to use the conformance tester. I'd rather we do extra work in one place to construct good test cases than every implementer work to adapt their updaters to issue error codes that exactly match our expectations.

**Argument 2.5: Many error codes encourages test mode divergence from live code.**
While test mode could be required for some implementations, the more logic we demand of it, the further it could drift from their live, production code. In the ideal solution, a Wrapper module is thin and it is possible to have conformance tests run with every build of live code, but that can only work if we can test live code or test with only minimal modifications, preferably contained in a static Wrapper module.

**Argument 3: Many error codes requires detailed and precise specification of behavior.**
The expected behavior if an updater contacts one mirror with invalid metadata and one mirror with valid metadata is simply to update, right? Even the reference implementation throws errors from other mirrors away if one mirror works out. Is that what we expect, or do we expect to get an array of responses per mirror?
A dictionary of responses per mirror means we're specifying that format. It's one more hoop for implementers to jump through.
In the absence of a successful update from one mirror, it might be perfectly sensible for a given Updater not to protest if it finds invalid metadata, but just not accept it and try again a few times or contact the most authoritative source.
I'm sure there would be debates about which error code is more appropriate in a particular scenario.