### PR TITLE
TAP 7: Improve Rationale section - cut and clarify

### DIFF
--- a/tap7.md
+++ b/tap7.md
@@ -77,8 +77,8 @@ will pass in sets of metadata and target files. In response, the wrapped
 Updater will provide return values indicating successful update or failure to
 update, and the Tester will compare these to the expected values for each test
 data set. In general, these data sets constitute a battery of attacks against
-which the Updater should be resilient, contrasted by controls which should
-succeed.
+which the Updater should be resilient, contrasted by positive control cases
+which should succeed.
 
 Note that the Tester will only expect a matching success-or-failure code
 instead of a specific code indicating the type of attack detected or error

--- a/tap7.md
+++ b/tap7.md
@@ -53,27 +53,32 @@ an important step in checking if an implementation is TUF-conformant.
 # Rationale
 
 Developers need a convenient way of verifying whether an implementation
-conforms to the TUF specification. Such a verification could be quite desirable,
-as it would affirm that the tested implementation meets a recognized standard of
-secure operation. One possible verification method could be to define, and ideally
-automate, the expected outcome of an update request when given different sets of
-input metadata. If an implementation is given the Root file and instructed to
-download a particular package, its ability to correctly download both the required
-top-level metadata and the requested package could indicate conformance.  Moreover,
-if it is able to do so while still preventing the attacks listed in the specification,
-that claim becomes stronger.  Consequently, any
-implementation of TUF would need some way of accepting given metadata
-and indicating when it has detected a particular attack.
+conforms to the TUF specification, affirming that the tested
+implementation meets a recognized standard of secure operation.
 
-This TAP prescribes that an implementation of a client updater ("Updater")
-employ a wrapper module ("Wrapper") that implements a common set of functions
-defined in this document. These can be called by a general TUF Conformance
-Tester ("Tester"), which will pass in sets of metadata and target files. The
-Tester will determine based on output produced by the wrapped Updater --
-including error codes that signal that particular attacks have been detected --
-whether or not the Updater is conformant with the TUF specification. In
-general, these constitute a battery of attacks against which the Updater should
-be resilient.
+The strategy for testing TUF conformance proposed in this TAP is to generate
+sets of metadata and targets with the expectation that all implementations
+should react to certain sets by successfully validating and updating, and all
+implementations should react to other sets by rejecting the invalid metadata or
+targets. Determining which data sets an implementation accepts and which it
+rejects allows us to determine the implementation's TUF conformance, including
+its resilience against the attacks listed in the TUF Specification (section
+1.5.2).
+
+Toward this end, it is necessary to define a test harness that allows a
+conformance tester to run the updater implementation, provide it with data it
+can interpret, and receive a success or failure code in response.
+
+Therefore, This TAP prescribes that an implementation of a client updater
+("Updater") have a corresponding custom wrapper module ("Wrapper") that
+implements a common set of functions defined in this document. These Wrapper
+functions will be called by a general TUF Conformance Tester ("Tester"), which
+will pass in sets of metadata and target files. In response, the wrapped
+Updater will provide return values indicating successful update or failure to
+update, and the Tester will compare these to the expected values for each test
+data set. In general, these data sets constitute a battery of attacks against
+which the Updater should be resilient, contrasted by controls which should
+succeed.
 
 The behavior necessary to provide the Conformance Tester with what it needs to
 judge conformance may be slightly different from the usual or production

--- a/tap7.md
+++ b/tap7.md
@@ -80,8 +80,17 @@ data set. In general, these data sets constitute a battery of attacks against
 which the Updater should be resilient, contrasted by controls which should
 succeed.
 
+Note that the Tester will only expect a matching success-or-failure code
+instead of a specific code indicating the type of attack detected or error
+encountered (expired metadata, bad signature, replay attack, fewer than the
+threshold number of signatures, etc.). This is in order to simplify work for
+Updater implementers. This will entail more test and control cases, but should
+make it easier for implementers to use the Conformance Tester without
+substantial changes to Updaters or too much extra work writing Wrapper
+functions.
+
 The behavior necessary to provide the Conformance Tester with what it needs to
-judge conformance may be slightly different from the usual or production
+judge conformance may still be slightly different from the usual or production
 behavior of the Updater, resulting in a need for a testing mode, or logic in
 the Wrapper to interpret behavior. For example, if errors are usually ignored
 rather than producing any return value, that's something that may be adjusted
@@ -469,14 +478,6 @@ is available, and an [example is available below](#example-wrapper) as well.
                          helpful to provide for test output)
 
         ```
-
-Note that the Tester will only expect a matching success-or-failure code from
-`update_client` instead of the correct code from a long a list of specific
-error codes (expired metadata, bad signature, replay attack, fewer than the
-threshold number of signatures, etc.) in order to simplify work for Updater
-implementers. This will entail more test and control cases, but should make it
-easier for implementers to use the Conformance Tester without substantial
-changes to Updaters or too much extra work writing Wrapper functions.
 
 
 A code skeleton that can be filled in by implementers is provided


### PR DESCRIPTION
This PR rewrites the Rationale section. Among the changes:

- removal of reference to error codes
- trimming some pronouns
- connecting conjunctions
- being meticulously explicit
- moving the 2-vs-many return codes rationale to the Rationale section (rather than the Wrapper Specification)