### PR TITLE
TAP 7: Full Re-read Revisions

### DIFF
--- a/tap7.md
+++ b/tap7.md
@@ -239,7 +239,7 @@ tap4-support: false
 The Wrapper must implement three functions. These are specified in detail
 [below](#wrapper-functions). In brief, the Tester will call the Wrapper's
 `set_up_initial_client_metadata` and `set_up_repositories` functions to assign
-initial trusted metadata to the client and put metadata and targets on the
+initial trusted metadata to the client, and put metadata and targets on the
 repository, respectively. After this, the Tester will call the Wrapper's
 `attempt_client_update` function to perform the test itself, instructing the
 client to try to update. The Tester will judge the correctness of the result
@@ -604,7 +604,7 @@ TUF Reference Implementation. (This can also be seen
     # Copy the provided metadata into a directory that we'll host.
     if os.path.exists('hosted'):
       shutil.rmtree('hosted')
-    assert os.path.exists(test_data_dir + '/test_repo'), 'Invalid ' + \
+    assert os.path.exists(test_data_dir + '/test_repo'), 'Invalid ' \
         'test_data_dir - we expect a test_repo directory.'
     shutil.copytree(test_data_dir + '/test_repo', 'hosted')
 

--- a/tap7.md
+++ b/tap7.md
@@ -538,6 +538,9 @@ TUF Reference Implementation. (This can also be seen
     global updater
     global server_process
 
+    # End hosting from any previous test.
+    kill_server()
+
     # Initialize the Updater implementation. We'll put trusted client files in
     # directory 'client', copying some of them from the provided metadata.
     tuf.settings.repositories_directory = 'client' # where client stores repo info
@@ -676,9 +679,11 @@ TUF Reference Implementation. (This can also be seen
     Kills the forked process that is hosting the repositories via Python's
     simple HTTP server
     """
+    global server_process
     if server_process is not None:
       print('Killing server process with pid: ' + str(server_process.pid))
       server_process.kill()
+      server_process = None
 ```
 
 

--- a/tap7.md
+++ b/tap7.md
@@ -460,16 +460,15 @@ is available, and an [example is available below](#example-wrapper) as well.
 
 - 3: **`attempt_client_update(target_filepath)`**:
     - Purpose:
-        Refreshes metadata and causes the client to attempt to (obtain and)
-        validate a particular target,
-        along with all metadata required to do so in a secure manner conforming to
-        the TUF specification.
+        Cause the client to attempt to refresh metadata from the repository
+        and obtain and validate a particular target, in a secure manner
+        conforming to the TUF specification.
 
         This function will have to translate Updater behavior/output into the
-        return values (below) that the Tester expects, based on
-        whether or not the Updater detects a particular attack. `update_client`
-        must return the appropriate code to the Tester, which will evaluate them
-        against what it expects.
+        return values (below) that the Tester expects, based on whether or not
+        the Updater updates successfully. It must return the appropriate value
+        to the Tester, which will evaluate this return value against what it
+        expects.
 
     - Arguments:
         - `target_filepath`:
@@ -521,7 +520,7 @@ TUF Reference Implementation. (This can also be seen
     This is an example of a Wrapper module, which enables the Conformance Tester
     (as described in TUF TAP 7) to communicate with a particular TUF-conformant
     Updater implementation - in this case, the pre-TAP4 TUF Reference
-    Implementation (configuration file option tap4-support: false).
+    Implementation (configuration file option tap_4_support: false).
 
     The Conformance Tester will call the functions listed here in order to
     perform the tests necessary to ascertain the conformance of the Updater to
@@ -556,14 +555,10 @@ TUF Reference Implementation. (This can also be seen
       Sets the client's initial state up for a future test, providing it with
       metadata to be treated as already-validated.
 
-      Note that the full function docstring is available in the text of TAP 7.
+      The full function docstring is available in the text of TAP 7 and in
+      tap7_wrapper_skeleton.py.
     """
-    # Client Setup
     global updater
-    global server_process
-
-    # End hosting from any previous test.
-    kill_server()
 
     # Initialize the Updater implementation. We'll put trusted client files in
     # directory 'client', copying some of them from the provided metadata.
@@ -586,12 +581,30 @@ TUF Reference Implementation. (This can also be seen
     updater = tuf.client.updater.Updater('test_repo', repository_mirrors)
 
 
+
+
+
+  def set_up_repositories(test_data_dir, keys, instructions):
+    """
+      Sets the repository files that will be available to the Updater when
+      attempt_client_update runs.
+
+      The full function docstring is available in the text of TAP 7 and in
+      tap7_wrapper_skeleton.py.
+    """
+    global server_process
+
+    # End hosting from any previous test.
+    kill_server()
+
     # Repository Setup
 
     # Copy the provided metadata into a directory that we'll host.
     if os.path.exists('hosted'):
       shutil.rmtree('hosted')
-    shutil.copytree(trusted_data_dir + '/test_repo', 'hosted')
+    assert os.path.exists(test_data_dir + '/test_repo'), 'Invalid ' + \
+        'test_data_dir - we expect a test_repo directory.'
+    shutil.copytree(test_data_dir + '/test_repo', 'hosted')
 
     # Start up hosting for the repository.
     os.chdir('hosted')
@@ -610,43 +623,6 @@ TUF Reference Implementation. (This can also be seen
 
 
 
-  def set_up_repositories(test_data_dir, keys, instructions):
-    """
-      Sets the repository files that will be made available to the Updater when
-      attempt_client_update runs.
-
-      The full docstring is available above, in the text of TAP 7.
-    """
-
-    # Replace the existing repository files with the new ones.
-    # The commands here are somewhat awkward in order to try to achieve a quick
-    # swap-in for live-hosted files using individually-atomic move commands.
-
-    # Destroy any lingering temp directories.
-    if os.path.exists('temp_metadata'):
-      shutil.rmtree('temp_metadata')
-    if os.path.exists('temp_targets'):
-      shutil.rmtree('temp_targets')
-    if os.path.exists('old_metadata'):
-      shutil.rmtree('old_metadata')
-    if os.path.exists('old_targets'):
-      shutil.rmtree('old_targets')
-
-    metadata_directory = test_data_dir + '/test_repo/metadata'
-    targets_directory = test_data_dir + '/test_repo/targets'
-
-    # Copy the contents of the provided test_data_dir to temp directories that
-    # we'll move into place afterwards.
-    shutil.copytree(metadata_directory, 'temp_metadata')
-    shutil.copytree(targets_directory, 'temp_targets')
-    shutil.move('hosted/metadata', 'old_metadata')
-    shutil.move('temp_metadata', 'hosted/metadata')
-    shutil.move('hosted/targets', 'old_targets')
-    shutil.move('temp_targets', 'hosted/targets')
-    shutil.rmtree('old_targets')
-    shutil.rmtree('old_metadata')
-
-
 
   def attempt_client_update(target_filepath):
     """
@@ -656,10 +632,9 @@ TUF Reference Implementation. (This can also be seen
       along with all metadata required to do so in a secure manner conforming to
       the TUF specification.
 
-      The full docstring is available above, in the text of TAP 7.
+      The full function docstring is available in the text of TAP 7 and in
+      tap7_wrapper_skeleton.py.
     """
-
-
 
     try:
       # Run the updater. Refresh top-level metadata and try updating
@@ -673,9 +648,9 @@ TUF Reference Implementation. (This can also be seen
       # following the Client Workflow instructions (TUF specification section
       # 5.1).
       # If the calls above haven't raised errors, then the file has downloaded
-      # and validated and all metadata checks succeeded from at least one mirror,
-      # so we can return 0 here. For good measure, we check to make sure the
-      # file exists where we expect it.
+      # and validated and all metadata checks succeeded on metadata from at least
+      # one mirror, so we can return 0 here. For good measure, we check to make
+      # sure the file exists where we expect it.
       if os.path.exists('client/validated_targets/' + target_filepath):
         return 0
       else:
@@ -696,6 +671,7 @@ TUF Reference Implementation. (This can also be seen
 
 
 
+
   # This function is not related to any Wrapper requirement; it's just here to
   # clean things up after we're done.
   def kill_server():
@@ -708,6 +684,7 @@ TUF Reference Implementation. (This can also be seen
       print('Killing server process with pid: ' + str(server_process.pid))
       server_process.kill()
       server_process = None
+    atexit.unregister(kill_server) # Avoid running kill_server multiple times.
 ```
 
 

--- a/tap7.md
+++ b/tap7.md
@@ -255,9 +255,9 @@ substantially, the Wrapper may need to perform additional work, such as:
  - Moving metadata or target files into the directory structure the Updater
  implementation expects
  - If, e.g., the Updater doesn't have a notion of a filesystem, the Wrapper may
- need to read the files the tester provides and distribute data to the Updater
+ need to read the files the Tester provides and distribute data to the Updater
  in the manner the Updater expects.
- - Translate metadata from the format the tester provides into the custom
+ - Translate metadata from the format the Tester provides into the custom
  format the Updater expects, potentially re-signing metadata if the Updater
  will expect signatures over a different format
  - If the Updater's communication model involves different synchronization
@@ -325,18 +325,19 @@ is available, and an [example is available below](#example-wrapper) as well.
                      |- root.json
             ```
 
-          filepaths in the targets directory map directly to the filepaths
+          Filepaths in the targets directory map directly to the filepaths
           used to identify targets in the repository. For example, a target
-          identified in metadata with the filepath 'package1/tarball.tar' will
+          identified in metadata with the filepath 'package1/tarball.tar' would
           be found in 'targets/package1/tarball.tar'.
 
         - `keys`:
           If the Updater can process signatures in TUF's default metadata, then
-          you SHOULD IGNORE this argument.
+          the Wrapper SHOULD IGNORE this argument.
           This is provided only in case the metadata format the Updater expects
           signatures to be made over is not the same as the metadata format that
           the TUF reference implementation signs over (canonicalized JSON).
-          If the Updater uses a different metadata format, then you may need to
+          If the Updater uses a different metadata format, then the Wrapper may
+          need to
           re-sign the metadata the Tester provides in the `trusted_data_dir`.
           This dict contains the signing keys that can be used to re-sign the
           metadata. The format of this dictionary of keys is as follows.
@@ -394,18 +395,19 @@ is available, and an [example is available below](#example-wrapper) as well.
 
         - `instructions`:
           If the Updater can process signatures in TUF's default metadata, then
-          you SHOULD IGNORE this argument.
+          the Wrapper SHOULD IGNORE this argument.
           This, too, is provided only in case the metadata format the Updater
           expects signatures to be made over is not the same as the metadata
           format that the TUF reference implementation signs over
           (canonicalized JSON).
-          If you'll be re-signing the metadata provided here, then this
-          dictionary of instructions will tell you what, if any, modifications
+          If the Wrapper will be re-signing the metadata provided here, then
+          this
+          dictionary of instructions will tell list what, if any, modifications
           to make. For example, {'invalidate_signature': True} instructs that
           the signature be made and then some byte(s) in it be modified so that
           it is no longer a valid signature over the metadata. Most tests
           should not require this, but some may; this should be documented in
-          the list of test cases.
+          the list of test cases and the Tester documentation.
 
     - Returns: None
 

--- a/tap7.md
+++ b/tap7.md
@@ -203,9 +203,8 @@ the location of a configuration file.
 The configuration file includes the name of the module that provides the
 Wrapper functions specified above, along with any necessary restrictions on
 TUF functionality, such as the list of
-cryptographic key types supported by the Updater, the number of root keys,
-thresholds, etc.  The configuration file is needed because restrictions
-are not shared equally across all implementations.
+cryptographic key types supported by the Updater.  The configuration file is
+needed because restrictions are not shared equally across all implementations.
 For example, the Go implementation might only support ECDSA keys, whereas
 another might support Ed25519 and RSA keys.
 

--- a/tap7.md
+++ b/tap7.md
@@ -450,11 +450,11 @@ is available, and an [example is available below](#example-wrapper) as well.
     - Arguments:
         - `target_filepath`:
           The path of a target file that the Updater should try to update.
-          This must be inside the `targets_directory` directory provided to
-          `update_repo`, and it should be written relative to
+          This must be inside the directory `targets_directory`, provided to
+          the `update_repo` call, and it should be written relative to
           `targets_directory`. As noted previously, it is not necessary for the
-          Updater to have a notion of files; `update_client` may abstract this
-          away.
+          Updater to have a notion of a filesystem; `update_client` may
+          abstract this away.
 
     - Returns:
         An integer describing the result of the attempted update. This value is

--- a/tap7.md
+++ b/tap7.md
@@ -273,7 +273,7 @@ called by the Tester.
 [A skeletal module defining the functions](tap7_resources/tap7_wrapper_skeleton.py)
 is available, and an [example is available below](#example-wrapper) as well.
 
-- 1: **`initialize_updater(trusted_data_dir, keys, instructions)`**:
+- 1: **`set_up_initial_client_metadata(trusted_data_dir, keys, instructions)`**:
     - Purpose:
         Sets the client's initial state up for a future test, providing it with
         metadata to be treated as already-validated. A client Updater delivered
@@ -296,7 +296,7 @@ is available, and an [example is available below](#example-wrapper) as well.
           `test_repo`.
 
           The data provided for
-          `initialize_updater` should be treated as already validated.
+          `set_up_initial_client_metadata` should be treated as already validated.
 
           Contents of `trusted_data_dir`:
             ```
@@ -415,7 +415,7 @@ is available, and an [example is available below](#example-wrapper) as well.
 
     - Returns: None
 
-- 2: **`update_repo(test_data_dir, keys, instructions)`**:
+- 2: **`set_up_repositories(test_data_dir, keys, instructions)`**:
     - Purpose:
         Sets the repository files, metadata and targets. This will be the
         data that should be made available to the Updater when the Updater
@@ -428,19 +428,19 @@ is available, and an [example is available below](#example-wrapper) as well.
           treated normally by the Updater (not as initially-shipped, trusted
           data, that is).
           The directory contents will have the same structure as those of
-          `trusted_data_dir` in `initialize_updater` above, but lacking a
           `map.json` file.
+          `trusted_data_dir` in `set_up_initial_client_metadata` above, but lacking a
 
         - `keys`:
-          See `initialize_updater` above.
+          See `set_up_initial_client_metadata` above.
 
         - `instructions`:
-          See `initialize_updater` above.
+          See `set_up_initial_client_metadata` above.
 
     - Returns: None
 
 
-- 3: **`update_client(target_filepath)`**:
+- 3: **`attempt_client_update(target_filepath)`**:
     - Purpose:
         Refreshes metadata and causes the client to attempt to (obtain and)
         validate a particular target,
@@ -457,9 +457,9 @@ is available, and an [example is available below](#example-wrapper) as well.
         - `target_filepath`:
           The path of a target file that the Updater should try to update.
           This must be inside the directory `targets_directory`, provided to
-          the `update_repo` call, and it should be written relative to
+          the `set_up_repositories` call, and it should be written relative to
           `targets_directory`. As noted previously, it is not necessary for the
-          Updater to have a notion of a filesystem; `update_client` may
+          Updater to have a notion of a filesystem; `attempt_client_update` may
           abstract this away.
 
     - Returns:
@@ -533,7 +533,7 @@ TUF Reference Implementation. (This can also be seen
   updater = None
   server_process = None
 
-  def initialize_updater(trusted_data_dir, keys, instructions):
+  def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
     """
       Sets the client's initial state up for a future test, providing it with
       metadata to be treated as already-validated.
@@ -592,10 +592,10 @@ TUF Reference Implementation. (This can also be seen
 
 
 
-  def update_repo(test_data_dir, keys, instructions):
+  def set_up_repositories(test_data_dir, keys, instructions):
     """
       Sets the repository files that will be made available to the Updater when
-      update_client runs.
+      attempt_client_update runs.
 
       The full docstring is available above, in the text of TAP 7.
     """
@@ -630,7 +630,7 @@ TUF Reference Implementation. (This can also be seen
 
 
 
-  def update_client(target_filepath):
+  def attempt_client_update(target_filepath):
     """
     <Purpose>
       Refreshes metadata and causes the client to attempt to (obtain and)
@@ -721,7 +721,7 @@ specified in the TUF Specification.)
 
 Suppose that metadata that the Updater receives must be encoded in DER (rather
 than JSON). In this case, the Wrapper will need to convert the metadata
-received from the Tester in `initialize_updater` and `update_repo` (specified
+received from the Tester in `set_up_initial_client_metadata` and `set_up_repositories` (specified
 in [Wrapper Functions](#wrapper-functions) above).
 
 For an example of how such code might look, consider the JSON-to-DER converter
@@ -740,7 +740,7 @@ new format (foreign to TUF).
 In the second case, the converted metadata must also be re-signed, so that the
 Updater will be able to correctly validate the metadata.
 
-For this reason, `initialize_updater` and `update_repo` also provide arguments
+For this reason, `set_up_initial_client_metadata` and `set_up_repositories` also provide arguments
 `keys` and `instructions`. The keys in `keys` will allow the Wrapper to
 re-sign the metadata provided in a manner that the Updater will expect. If
 there were manipulations made to the resulting metadata for test purposes
@@ -755,8 +755,8 @@ where metadata or update files are not saved to a file system on the
 device, but are instead stored in the absence of a file system.
 
 In such cases, the Wrapper should take the metadata and target file data
-provided to `initialize_updater` and `update_repo` and provide them to the
-Updater in whatever form it expects.
+provided to `set_up_initial_client_metadata` and `set_up_repositories` and
+provide them to the Updater in whatever form it expects.
 
 
 ## Summary of Steps for Conformance Testing

--- a/tap7.md
+++ b/tap7.md
@@ -763,12 +763,10 @@ Updater in whatever form it expects.
 In summary, the steps that should be followed to test an Updater for
 conformance to the TUF Specification are as follows:
 
-```
-(1) Fill in the functions in the
-[Wrapper module skeleton]((tap7_resources/tap7_wrapper_skeleton.py)).
-(2) Configure Tester to abide by the adopter's repository restrictions.
-(3) Run Tester and confirm that all tests have passed.
-```
+1. Fill in the functions in the
+[Wrapper module skeleton](tap7_resources/tap7_wrapper_skeleton.py).
+2. Configure Tester to abide by the adopter's repository restrictions.
+3. Run Tester and confirm that all tests have passed.
 
 # Security Analysis
 

--- a/tap7.md
+++ b/tap7.md
@@ -364,6 +364,10 @@ is available, and an [example is available below](#example-wrapper) as well.
             }
             ```
 
+            This listing indicates what key(s) should be used to sign each role
+            in the test metadata. Sometimes (in the case of some attacks),
+            these will not be the correct keys for the role.
+
           Here's an excerpt from a particular example:
           ```javascript
           {

--- a/tap7.md
+++ b/tap7.md
@@ -206,7 +206,8 @@ TUF functionality, such as the list of
 cryptographic key types supported by the Updater.  The configuration file is
 needed because restrictions are not shared equally across all implementations.
 For example, the Go implementation might only support ECDSA keys, whereas
-another might support Ed25519 and RSA keys.
+another might support Ed25519 and RSA keys. The full list of configuration
+options will be provided in documentation for the Conformance Tester.
 
 An example of a `.tuf-tester.yml` configuration file for an Updater:
 
@@ -229,7 +230,6 @@ mirror-support: false
 # If TAP 4 (multi-repository / map file support) is not supported, set to
 # false. (Default is true.)
 tap4-support: false
-...
 ```
 
 

--- a/tap7.md
+++ b/tap7.md
@@ -236,34 +236,34 @@ tap4-support: false
 
 ## Wrapper Specification
 
-The Wrapper must implement the three functions specified
-[below](#wrapper-functions). The Tester will use them in this manner:
-- The Tester will call the Wrapper's `initialize_updater` function to provide
-initial trusted metadata for a test or series of tests.
-- For each test, the Tester will call the Wrapper's `update_repo` function
-with unvalidated new metadata and targets. This metadata will describe a new
-target not included in data provided to the earlier `initialize_updater` call.
-- The Tester will call the Wrapper's `update_client` function to instruct the
-Updater to try updating to the new target. `update_client` will return a value
-indicating success or failure. Based upon that value, the Tester will judge
-the behavior of the Updater in the provided test conformant or non-conformant.
+The Wrapper must implement three functions. These are specified in detail
+[below](#wrapper-functions). In brief, the Tester will call the Wrapper's
+`set_up_initial_client_metadata` and `set_up_repositories` functions to assign
+initial trusted metadata to the client and put metadata and targets on the
+repository, respectively. After this, the Tester will call the Wrapper's
+`attempt_client_update` function to perform the test itself, instructing the
+client to try to update. The Tester will judge the correctness of the result
+based on the return value from `attempt_client_update` that indicates success
+or failure to update.
 
-Note also, however, that because Updater implementations may vary
-substantially, the Wrapper may need to perform additional work, such as:
- - Calling an external binary with, e.g., the subprocess module, in order to
- run an Updater implementation that is not in Python.
- - Moving metadata or target files into the directory structure the Updater
- implementation expects
- - If, e.g., the Updater doesn't have a notion of a filesystem, the Wrapper may
+Beyond the base functionality specified, because different Updaters may
+operate very differently, the Wrapper functions may have other work to do. The
+[Dealing with Implementation Restrictions](#dealing-with-implementation-restrictions)
+section below addresses a variety of such scenarios in detail. Here are some
+examples to keep in mind while reading the specification. Wrapper functions
+might:
+ - use subprocess to call an external binary to run a non-Python Updater.
+ - move metadata or target files into the directory structure an Updater
+ implementation expects.
+ - if, e.g., the Updater doesn't have a notion of a filesystem, the Wrapper may
  need to read the files the Tester provides and distribute data to the Updater
  in the manner the Updater expects.
- - Translate metadata from the format the Tester provides into the custom
+ - translate metadata from the format the Tester provides into the custom
  format the Updater expects, potentially re-signing metadata if the Updater
- will expect signatures over a different format
- - If the Updater's communication model involves different synchronization
- (e.g. server push vs client pull), the update_client() Wrapper function will
- need to bridge this; for example, it may need to wait and collect results from
- some separate process.
+ will expect signatures over a different format.
+ - bridge different communication models - for example, if the Updater's
+ communication model involves server push vs client pull, or if there will need
+ to be asynchronous events to wait for and collect results from.
 
 
 ### Wrapper Functions

--- a/tap7.md
+++ b/tap7.md
@@ -708,7 +708,8 @@ Suppose, for example, that the Updater implementation supports only signatures
 using Ed25519 keys.
 
 This restriction can be handled by configuring the conformance tool via
-its `.tuf-tester.yml` configuration file. The developer can add:
+its `.tuf-tester.yml` [configuration file](#configuration-file-specification).
+The developer can add:
 ```
 keytype: ed25519
 ```

--- a/tap7.md
+++ b/tap7.md
@@ -255,12 +255,14 @@ might:
  - use subprocess to call an external binary to run a non-Python Updater.
  - move metadata or target files into the directory structure an Updater
  implementation expects.
- - if, e.g., the Updater doesn't have a notion of a filesystem, the Wrapper may
- need to read the files the Tester provides and distribute data to the Updater
- in the manner the Updater expects.
- - translate metadata from the format the Tester provides into the custom
- format the Updater expects, potentially re-signing metadata if the Updater
- will expect signatures over a different format.
+ - if, e.g., the Updater doesn't have a notion of a filesystem, read the files
+ the Tester provides and distribute data to the Updater in the manner the
+ Updater expects.
+ - if the Updater uses a different metadata format, translate
+ metadata from the format the Tester provides into the format the Updater
+ expects.
+ - if the Updater requires signatures to be over a different format, re-sign
+ metadata after translating it.
  - bridge different communication models - for example, if the Updater's
  communication model involves server push vs client pull, or if there will need
  to be asynchronous events to wait for and collect results from.

--- a/tap7.md
+++ b/tap7.md
@@ -239,15 +239,14 @@ tap4-support: false
 The Wrapper must implement the three functions specified
 [below](#wrapper-functions). The Tester will use them in this manner:
 - The Tester will call the Wrapper's `initialize_updater` function to provide
-initial trusted metadata.
-- For each test case, the Tester will call the Wrapper's `update_repo` function
+initial trusted metadata for a test or series of tests.
+- For each test, the Tester will call the Wrapper's `update_repo` function
 with unvalidated new metadata and targets. This metadata will describe a new
 target not included in data provided to the earlier `initialize_updater` call.
 - The Tester will call the Wrapper's `update_client` function to instruct the
 Updater to try updating to the new target. `update_client` will return a value
 indicating success or failure. Based upon that value, the Tester will judge
-the behavior of the Updater in the provided test case conformant or
-non-conformant.
+the behavior of the Updater in the provided test conformant or non-conformant.
 
 Note also, however, that because Updater implementations may vary
 substantially, the Wrapper may need to perform additional work, such as:

--- a/tap7.md
+++ b/tap7.md
@@ -298,7 +298,15 @@ is available, and an [example is available below](#example-wrapper) as well.
           The data provided for
           `set_up_initial_client_metadata` should be treated as already validated.
 
-          Contents of `trusted_data_dir`:
+          In most cases, the contents of `trusted_data_dir` will simply be:
+            ```
+            - map.json // if TAP 4 is supported
+            - test_repo
+                     |-metadata
+                          |- root.json
+            ```
+
+          But more may be provided:
             ```
             - map.json   // see TAP 4
             - <repository_1_name>
@@ -310,25 +318,11 @@ is available, and an [example is available below](#example-wrapper) as well.
                               |- <a delegated role>.json
                               |- <another delegated role>.json
                               |   ...
-                        |- targets
-                              |- <some_target.img>
-                              |-  ...
             - <repository_2_name>
                         |- metadata
                               |- root.json
                         // etc.
             ```
-          In most cases, this will contain simply:
-            ```
-            - map.json // if TAP 4 is supported
-            - test_repo
-                     |- root.json
-            ```
-
-          Filepaths in the targets directory map directly to the filepaths
-          used to identify targets in the repository. For example, a target
-          identified in metadata with the filepath 'package1/tarball.tar' would
-          be found in 'targets/package1/tarball.tar'.
 
         - `keys`:
           If the Updater can process signatures in TUF's default metadata, then
@@ -428,8 +422,32 @@ is available, and an [example is available below](#example-wrapper) as well.
           treated normally by the Updater (not as initially-shipped, trusted
           data, that is).
           The directory contents will have the same structure as those of
-          `map.json` file.
-          `trusted_data_dir` in `set_up_initial_client_metadata` above, but lacking a
+          `trusted_data_dir` in `set_up_initial_client_metadata` above, but
+          will lack a `map.json` file (regardless of TAP 4 support), and will
+          have `targets` directories alongside each repository's `metadata`
+          directory. For example:
+            ```
+            - <repository_1_name>
+                        |- metadata
+                              |- root.json
+                              |- timestamp.json
+                              |- snapshot.json
+                              |- targets.json
+                              |- <a delegated role>.json
+                              |- <another delegated role>.json
+                              |   ...
+                        |- targets
+                              |- <some_target.img>
+                              |-  ...
+            - <repository_2_name>
+                        |- metadata
+                              |- root.json
+                        // etc.
+            ```
+          Filepaths in the targets directory map directly to the filepaths
+          used to identify targets in the repository. For example, a target
+          identified in metadata with the filepath 'package1/tarball.tar' would
+          be found in 'targets/package1/tarball.tar'.
 
         - `keys`:
           See `set_up_initial_client_metadata` above.

--- a/tap7_resources/tap7_tester_sample.py
+++ b/tap7_resources/tap7_tester_sample.py
@@ -1,5 +1,5 @@
 """
-Sample tester script.
+Sample tester code.
 
 The Tester will execute tests along these lines.
 

--- a/tap7_resources/tap7_tester_sample.py
+++ b/tap7_resources/tap7_tester_sample.py
@@ -12,13 +12,14 @@ import tap7_wrapper_example as wrapper
 
 def main():
   # Deliver initial trusted metadata state to the Updater client.
-  wrapper.initialize_updater(
+  wrapper.set_up_initial_client_metadata(
       trusted_data_dir=SAMPLE_1_DIR, keys=KEYS, instructions=None)
 
   # Deliver new metadata & targets state to the repository.
   # This new state includes the target file 'firmware.img' and metadata validly
   # signing it.
-  wrapper.update_repo(test_data_dir=SAMPLE_2_DIR, keys=KEYS, instructions=None)
+  wrapper.set_up_repositories(
+      test_data_dir=SAMPLE_2_DIR, keys=KEYS, instructions=None)
 
   randomized_tests = [('firmware.img', 0), ('firmware_b.img', 1)]
   expected_results = []
@@ -28,7 +29,7 @@ def main():
   # Store the return code.
   for target, expected_result in randomized_tests:
     expected_results.append(expected_result)
-    actual_result = wrapper.update_client(target)
+    actual_result = wrapper.attempt_client_update(target)
     actual_results.append(actual_result)
     if actual_result != expected_result:
       print('Test failure for ' + repr(target))

--- a/tap7_resources/tap7_wrapper_example.py
+++ b/tap7_resources/tap7_wrapper_example.py
@@ -13,9 +13,9 @@
   the TUF spec.
 
   The following three functions must be defined:
-   - initialize_updater
-   - update_repo
-   - update_client
+   - set_up_initial_client_metadata
+   - set_up_repositories
+   - attempt_client_update
  """
 # Python 2/3 compatibility
 from __future__ import print_function
@@ -41,7 +41,7 @@ from tuf.exceptions import *
 updater = None
 server_process = None
 
-def initialize_updater(trusted_data_dir, keys, instructions):
+def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
   """
     Sets the client's initial state up for a future test, providing it with
     metadata to be treated as already-validated.
@@ -167,7 +167,7 @@ def update_repo(test_data_dir, keys, instructions):
 
 
 
-def update_client(target_filepath):
+def attempt_client_update(target_filepath):
   """
   <Purpose>
     Refreshes metadata and causes the client to attempt to (obtain and)

--- a/tap7_resources/tap7_wrapper_example.py
+++ b/tap7_resources/tap7_wrapper_example.py
@@ -46,11 +46,9 @@ def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
     Sets the client's initial state up for a future test, providing it with
     metadata to be treated as already-validated.
 
-    Note that the full function docstring is available in the text of TAP 7
-    and in tap7_wrapper_skeleton.py.
+    The full function docstring is available in the text of TAP 7 and in
+    tap7_wrapper_skeleton.py.
   """
-
-  # Client Setup
   global updater
 
   # Initialize the Updater implementation. We'll put trusted client files in
@@ -82,8 +80,8 @@ def set_up_repositories(test_data_dir, keys, instructions):
     Sets the repository files that will be available to the Updater when
     attempt_client_update runs.
 
-    Note that the full function docstring is available in the text of TAP 7
-    and in tap7_wrapper_skeleton.py.
+    The full function docstring is available in the text of TAP 7 and in
+    tap7_wrapper_skeleton.py.
   """
   global server_process
 
@@ -125,8 +123,8 @@ def attempt_client_update(target_filepath):
     along with all metadata required to do so in a secure manner conforming to
     the TUF specification.
 
-    Note that the full function docstring is available in the text of TAP 7
-    and in tap7_wrapper_skeleton.py.
+    The full function docstring is available in the text of TAP 7 and in
+    tap7_wrapper_skeleton.py.
   """
 
   try:
@@ -141,9 +139,9 @@ def attempt_client_update(target_filepath):
     # following the Client Workflow instructions (TUF specification section
     # 5.1).
     # If the calls above haven't raised errors, then the file has downloaded
-    # and validated and all metadata checks succeeded at at least one mirror,
-    # so we can return 0 here. For good measure, we check to make sure the
-    # file exists where we expect it.
+    # and validated and all metadata checks succeeded on metadata from at least
+    # one mirror, so we can return 0 here. For good measure, we check to make
+    # sure the file exists where we expect it.
     if os.path.exists('client/validated_targets/' + target_filepath):
       return 0
     else:

--- a/tap7_resources/tap7_wrapper_example.py
+++ b/tap7_resources/tap7_wrapper_example.py
@@ -53,6 +53,9 @@ def initialize_updater(trusted_data_dir, keys, instructions):
   global updater
   global server_process
 
+    # End hosting from any previous test.
+    kill_server()
+
   # Initialize the Updater implementation. We'll put trusted client files in
   # directory 'client', copying some of them from the provided metadata.
   tuf.settings.repositories_directory = 'client' # where client stores repo info
@@ -248,6 +251,8 @@ def kill_server():
   Kills the forked process that is hosting the repositories via Python's
   simple HTTP server
   """
+  global server_process
   if server_process is not None:
     print('Killing server process with pid: ' + str(server_process.pid))
     server_process.kill()
+    server_process = None

--- a/tap7_resources/tap7_wrapper_example.py
+++ b/tap7_resources/tap7_wrapper_example.py
@@ -46,7 +46,8 @@ def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
     Sets the client's initial state up for a future test, providing it with
     metadata to be treated as already-validated.
 
-    Note that the full function docstring is available in the text of TAP 7.
+    Note that the full function docstring is available in the text of TAP 7
+    and in tap7_wrapper_skeleton.py.
   """
 
   # Client Setup
@@ -175,39 +176,9 @@ def attempt_client_update(target_filepath):
     along with all metadata required to do so in a secure manner conforming to
     the TUF specification.
 
-    This function will have to translate Updater behavior/output into the
-    return values (below) that the Tester expects, based on
-    whether or not the Updater detects a particular attack. update_client
-    must return the appropriate code to the Tester, which will evaluate them
-    against what it expects.
-
-  <Arguments>
-    target_filepath
-      The path of a target file that the Updater should try to update.
-      This must be inside the targets_directory directory provided to
-      update_repo, and it should be written relative to
-      targets_directory. As noted previously, it is not necessary for the
-      Updater to have a notion of files; update_client may abstract this
-      away.
-
-  <Returns>
-
-    An integer describing the result of the attempted update. This value is
-    what the Tester is ultimately testing.
-
-    return value     outcome
-    -----------      ------
-    0                SUCCESS: target identified by target_filepath has been
-                     obtained from one of the mirrors and validated per
-                     trustworthy metadata
-    1                FAILURE/rejection: unable to obtain a target identified
-                     by target_filepath from any of the known mirrors that
-                     is valid according to trustworthy metadata
-    2                an unknown error has occurred (never expected, but
-                     helpful to provide for test output)
+    Note that the full function docstring is available in the text of TAP 7
+    and in tap7_wrapper_skeleton.py.
   """
-
-
 
   try:
     # Run the updater. Refresh top-level metadata and try updating
@@ -240,6 +211,7 @@ def attempt_client_update(target_filepath):
 
   except:
     return 2
+
 
 
 

--- a/tap7_resources/tap7_wrapper_example.py
+++ b/tap7_resources/tap7_wrapper_example.py
@@ -93,7 +93,7 @@ def set_up_repositories(test_data_dir, keys, instructions):
   # Copy the provided metadata into a directory that we'll host.
   if os.path.exists('hosted'):
     shutil.rmtree('hosted')
-  assert os.path.exists(test_data_dir + '/test_repo'), 'Invalid ' + \
+  assert os.path.exists(test_data_dir + '/test_repo'), 'Invalid ' \
       'test_data_dir - we expect a test_repo directory.'
   shutil.copytree(test_data_dir + '/test_repo', 'hosted')
 

--- a/tap7_resources/tap7_wrapper_skeleton.py
+++ b/tap7_resources/tap7_wrapper_skeleton.py
@@ -16,9 +16,9 @@
   the TUF spec. More information is available in TAP 7 itself.
 
   The following three functions must be defined:
-   - initialize_updater
-   - update_repo
-   - update_client
+   - set_up_initial_client_metadata
+   - set_up_repositories
+   - attempt_client_update
  """
 # Python 2/3 compatibility
 from __future__ import print_function
@@ -27,7 +27,7 @@ from __future__ import division
 from __future__ import unicode_literals
 
 
-def initialize_updater(trusted_data_dir, keys, instructions):
+def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
   """
   <Purpose>
       Sets the client's initial state up for a future test, providing it with
@@ -51,7 +51,7 @@ def initialize_updater(trusted_data_dir, keys, instructions):
           test_repo.
 
           The data provided for
-          initialize_updater should be treated as already validated.
+          set_up_initial_client_metadata should be treated as already validated.
 
           Contents of trusted_data_dir:
             - map.json   // see TAP 4
@@ -178,7 +178,7 @@ def initialize_updater(trusted_data_dir, keys, instructions):
 
 
 
-def update_repo(test_data_dir, keys, instructions):
+def set_up_repositories(test_data_dir, keys, instructions):
   """
   <Purpose>
       Sets the repository files, metadata and targets. This will be the
@@ -193,14 +193,14 @@ def update_repo(test_data_dir, keys, instructions):
         treated normally by the Updater (not as initially-shipped, trusted
         data, that is).
         The directory contents will have the same structure as those of
-        trusted_data_dir in initialize_updater above, but lacking a
+        trusted_data_dir in set_up_initial_client_metadata above, but lacking a
         map.json file.
 
       keys
-        See above, in initialize_updater.
+        See above, in set_up_initial_client_metadata.
 
       instructions
-        See above, in initialize_updater.
+        See above, in set_up_initial_client_metadata.
 
 
   <Returns>
@@ -217,7 +217,7 @@ def update_repo(test_data_dir, keys, instructions):
   # Host the repository files in a manner that the client Updater can access.
   # For the examples provided for the TUF Reference Implementation, this
   # entails copying the files into the directory hosted by an HTTP server,
-  # which would be set up by initialize_updater.
+  # which would be set up by set_up_initial_client_metadata.
   # -----
 
   pass
@@ -225,7 +225,7 @@ def update_repo(test_data_dir, keys, instructions):
 
 
 
-def update_client(target_filepath):
+def attempt_client_update(target_filepath):
   """
   <Purpose>
     Refreshes metadata and causes the client to attempt to (obtain and)
@@ -235,7 +235,7 @@ def update_client(target_filepath):
 
     This function will have to translate Updater behavior/output into the
     return values (below) that the Tester expects, based on
-    whether or not the Updater detects a particular attack. update_client
+    whether or not the Updater detects a particular attack. attempt_client_update
     must return the appropriate code to the Tester, which will evaluate them
     against what it expects.
 
@@ -243,9 +243,9 @@ def update_client(target_filepath):
     target_filepath
       The path of a target file that the Updater should try to update.
       This must be inside the targets_directory directory provided to
-      update_repo, and it should be written relative to
+      set_up_repositories, and it should be written relative to
       targets_directory. As noted previously, it is not necessary for the
-      Updater to have a notion of files; update_client may abstract this
+      Updater to have a notion of files; attempt_client_update may abstract this
       away.
 
   <Returns>

--- a/tap7_resources/tap7_wrapper_skeleton.py
+++ b/tap7_resources/tap7_wrapper_skeleton.py
@@ -45,15 +45,21 @@ def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
           file.
 
           This structure allows for optional multi-repository support per
-          [TAP 4](tap4.md). If TAP 4 is not supported (See
-          [Configuration File](#configuration-file)), then map.json will be
+          (tap4.md). If TAP 4 is not supported (See
+          tap7.md#configuration-file-specification), then map.json will be
           excluded, and there will only be one repository directory, named
           test_repo.
 
           The data provided for
           set_up_initial_client_metadata should be treated as already validated.
 
-          Contents of trusted_data_dir:
+          In most cases, the contents of trusted_data_dir will simply be:
+            - map.json // if TAP 4 is supported
+            - test_repo
+                     |-metadata
+                          |- root.json
+
+          But more may be provided:
             - map.json   // see TAP 4
             - <repository_1_name>
                         |- metadata
@@ -64,26 +70,20 @@ def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
                               |- <a delegated role>.json
                               |- <another delegated role>.json
                               |   ...
-                        |- targets
-                              |- <some_target.img>
-                              |-  ...
             - <repository_2_name>
                         |- metadata
                               |- root.json
                         // etc.
-          In most cases, this will contain simply:
-            - map.json // if TAP 4 is supported
-            - test_repo
-                     |- root.json
 
       keys
           If the Updater can process signatures in TUF's default metadata, then
-          you SHOULD IGNORE this argument.
+          the Wrapper SHOULD IGNORE this argument.
           This is provided only in case the metadata format the Updater expects
           signatures to be made over is not the same as the metadata format that
-          TUF signs over (canonicalized JSON).
-          If the Updater uses a different metadata format, then you may need to
-          re-sign the metadata the Tester provides in the trusted_data_dir.
+          the TUF reference implementation signs over (canonicalized JSON).
+          If the Updater uses a different metadata format, then the Wrapper may
+          need to re-sign the metadata the Tester provides in the
+          trusted_data_dir.
           This dict contains the signing keys that can be used to re-sign the
           metadata. The format of this dictionary of keys is as follows.
           (Note that the individual keys resemble ANYKEY_SCHEMA in the
@@ -107,6 +107,10 @@ def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
 
               <repository_2_name>: {...}
             }
+
+            This listing indicates what key(s) should be used to sign each role
+            in the test metadata. Sometimes (in the case of some attacks),
+            these will not be the correct keys for the role.
 
           Here's an excerpt from a particular example:
           {
@@ -134,17 +138,22 @@ def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
             'director': {
               {'root': [{
                 ...
+
       instructions
         If the Updater can process signatures in TUF's default metadata, then
-        you SHOULD IGNORE this argument.
+        the Wrapper SHOULD IGNORE this argument.
         This, too, is provided only in case the metadata format the Updater
         expects signatures to be made over is not the same as the metadata
-        format that TUF signs over (canonicalized JSON).
-        If you'll be re-signing the metadata provided here, then this
-        dictionary of instructions will tell you what, if any, modifications
+        format that the TUF reference implementation signs over
+        (canonicalized JSON).
+        If the Wrapper will be re-signing the metadata provided here, then
+        this
+        dictionary of instructions will tell list what, if any, modifications
         to make. For example, {'invalidate_signature': True} instructs that
         the signature be made and then some byte(s) in it be modified so that
-        it is no longer a valid signature over the metadata.
+        it is no longer a valid signature over the metadata. Most tests
+        should not require this, but some may; this should be documented in
+        the list of test cases and the Tester documentation.
 
   <Returns>
     None
@@ -168,7 +177,7 @@ def set_up_initial_client_metadata(trusted_data_dir, keys, instructions):
   # for example).
   # This might entail adding it to a database, or whatever mechanism the
   # client employs to store this trusted information. For the TUF Reference
-  # Implementation, this simplky involves moving the metadata into client
+  # Implementation, this simply involves moving the metadata into client
   # directory <repository_name>/metadata/current directory.)
   # -----
 


### PR DESCRIPTION
Various edits made during a final read-through.

Changes in Round 1:
- Remove mention of number of root keys and root threshold in config
- Note that config options will be specified in Tester documentation
- initialize_updater may be called per test / test series
- handle multiple initialize_updater calls in wrapper example
- adjust appearance of some docstrings
- correct typos
- shift from 'you' to 'the Wrapper' where possible
- clarify how the keys argument should be interpreted in Wrapper functions
- add some links

Changes in Round 2 (based on Justin's feedback):
- rename Wrapper functions to make them more readily grokked
- move all repo setup from first Wrapper function to second
- rewrite Wrapper intro section so it's clear it's just an intro, and more understandable