### PR TITLE
TAP 11: Pre-release schedule

### DIFF
--- a/tap11.md
+++ b/tap11.md
@@ -19,8 +19,8 @@ May
 Note: The distribution version scheme of the project follows the
 (major.minor.micro) format.  Pre-releases of the project have a fixed `major`
 of 0, while the `minor` and `micro` segments can vary.  On occassion,
-developmental releases are made for testing and follow the `0.X.Y.devZ` version
-scheme.
+developmental releases are made available on PyPI for testing and follow the
+`0.X.Y.devZ` version scheme.
 
 # Release manager for pre-releases
 Vladimir Diaz <vladimir.v.diaz@gmail.com, @vladimir-v-diaz>
@@ -54,8 +54,8 @@ release dates are as follows:
 # Features
 Implemented features:
 * Conformance with specification, as last modified on [10 May 2018](https://github.com/theupdateframework/specification/blob/409739f2b8601e28d9330eeabeb454d9ef188e7d/tuf-spec.md).
-* Support design covered in Diplomat.
-* Support design covered in Mercury.
+* Support design and features covered in [Diplomat](https://github.com/theupdateframework/tuf/blob/b7872e1fe42a2c33090659394ef1e8c1cfe854cc/docs/papers/protect-community-repositories-nsdi2016.pdf).
+* Support design and features covered in [Mercury](https://github.com/theupdateframework/tuf/blob/b7872e1fe42a2c33090659394ef1e8c1cfe854cc/docs/papers/prevention-rollback-attacks-atc2017.pdf).
 * [TAP 4: Multiple repository consensus on entrusted targets](tap4.md).
 * [TAP 6: Include specification version in metadata](tap6.md).
 * [TAP 9: Mandatory metadata signing schemes](tap9.md).

--- a/tap11.md
+++ b/tap11.md
@@ -1,0 +1,63 @@
+* TAP: 11
+* Title: TUF Pre-release Schedule
+* Version: 1
+* Last-Modified: 15-June-2018
+* Author: Vladimir Diaz
+* Status: Draft
+* Type: Informational
+* Content-Type: text/markdown
+* Created: 15-June-2018
+
+# Abstract
+
+This TAP documents the release schedule for the pre-release of TUF.
+
+The distribution version scheme of the TUF project follows the
+(major.minor.micro) format.  Pre-releases have a `major` number of 0.  The
+`minor` and `micro` segments can vary.
+
+# Release Manager
+Vladimir Diaz <vladimir.v.diaz@gmail.com, @vladimir-v-diaz>
+PGP fingerprint: 3E87 BB33 9378 BC7B 3DD0 E5B2 5DEE 9B97 B0E2 289A
+
+# Lifespan
+
+The final pre-release is expected October 2019.
+
+# Release Schedule
+A new release of the project is expected every 3 months. The release cycle,
+upcoming tasks, and any stated goals are subject to change. The antipicated
+release dates are as follows:
+
+* January 2018
+
+* April 2018
+
+* July 2018 (no new features beyond this point.)
+
+* October 2018
+
+* January 2019
+
+* April 2019
+
+* July 2019
+
+* October 2019
+
+# Features
+Implemented features:
+* Conformance with specification, as last modified on [10 May 2018](https://github.com/theupdateframework/specification/blob/409739f2b8601e28d9330eeabeb454d9ef188e7d/tuf-spec.md).
+* Support design covered in Diplomat.
+* Support design covered in Mercury.
+* [TAP 4: Multiple repository consensus on entrusted targets](tap4.md).
+* [TAP 6: Include specification version in metadata](tap6.md).
+* [TAP 9: Mandatory metadata signing schemes](tap9.md).
+* [TAP 10: Remove native support for compressed metadata](tap10.md).
+* Linux, MacOS, and Windows support.
+* CLI to create and manage repos.
+*
+*
+
+# Copyright
+This document has been placed in the public domain.

--- a/tap11.md
+++ b/tap11.md
@@ -10,14 +10,19 @@
 
 # Abstract
 
-This TAP documents the release schedule for the pre-release versions of TUF
-(i.e., distributions that match the `0.X.Y` distribution identifier.
+This TAP covers the release schedule for the pre-release of the reference
+implementation.  Pre-releases match the `0.X.Y` distribution identifier, and
+conform with pre-1.0 versions of the official specification (last modified [10
+May
+2018](https://github.com/theupdateframework/specification/blob/409739f2b8601e28d9330eeabeb454d9ef188e7d/tuf-spec.md))
 
 Note: The distribution version scheme of the project follows the
 (major.minor.micro) format.  Pre-releases of the project have a fixed `major`
-number of 0, but the `minor` and `micro` segments can vary.
+of 0, while the `minor` and `micro` segments can vary.  On occassion,
+developmental releases are made for testing and follow the `0.X.Y.devZ` version
+scheme.
 
-# Release Manager
+# Release manager for pre-releases
 Vladimir Diaz <vladimir.v.diaz@gmail.com, @vladimir-v-diaz>
 PGP fingerprint: 3E87 BB33 9378 BC7B 3DD0 E5B2 5DEE 9B97 B0E2 289A
 
@@ -25,7 +30,7 @@ PGP fingerprint: 3E87 BB33 9378 BC7B 3DD0 E5B2 5DEE 9B97 B0E2 289A
 
 The final pre-release is expected October 2019.
 
-# Release Schedule
+# Release schedule
 A new release of the project is expected every 3 months. The release cycle,
 upcoming tasks, and any stated goals are subject to change. The antipicated
 release dates are as follows:
@@ -34,7 +39,7 @@ release dates are as follows:
 
 * April 2018
 
-* July 2018 (no new features beyond this point.)
+* July 2018 (no new features beyond this point, only bug and security fixes)
 
 * October 2018
 
@@ -44,7 +49,7 @@ release dates are as follows:
 
 * July 2019
 
-* October 2019
+* October 2019 (end-of-life)
 
 # Features
 Implemented features:
@@ -57,8 +62,6 @@ Implemented features:
 * [TAP 10: Remove native support for compressed metadata](tap10.md).
 * Linux, MacOS, and Windows support.
 * CLI to create and manage repos.
-*
-*
 
 # Copyright
 This document has been placed in the public domain.

--- a/tap11.md
+++ b/tap11.md
@@ -1,7 +1,7 @@
 * TAP: 11
-* Title: TUF Pre-release Schedule
+* Title: Pre-release schedule
 * Version: 1
-* Last-Modified: 15-June-2018
+* Last-Modified: 18-June-2018
 * Author: Vladimir Diaz
 * Status: Draft
 * Type: Informational
@@ -10,11 +10,12 @@
 
 # Abstract
 
-This TAP documents the release schedule for the pre-release of TUF.
+This TAP documents the release schedule for the pre-release versions of TUF
+(i.e., distributions that match the `0.X.Y` distribution identifier.
 
-The distribution version scheme of the TUF project follows the
-(major.minor.micro) format.  Pre-releases have a `major` number of 0.  The
-`minor` and `micro` segments can vary.
+Note: The distribution version scheme of the project follows the
+(major.minor.micro) format.  Pre-releases of the project have a fixed `major`
+number of 0, but the `minor` and `micro` segments can vary.
 
 # Release Manager
 Vladimir Diaz <vladimir.v.diaz@gmail.com, @vladimir-v-diaz>


### PR DESCRIPTION
This pull request contains a draft of `TAP 11: Pre-release schedule`.  This TAP covers the release schedule for the pre-releases of the reference implementation.