### PR TITLE
Tap8revision

### DIFF
--- a/tap8.md
+++ b/tap8.md
@@ -21,35 +21,40 @@ Performing a key rotation does not require parties that delegated trust to the
 role to change their delegation. Roles are thus able to rotate to new trusted
 keys independently, allowing keys to be changed more often.
 
-Conceptually, the rotation process says if you trusted threshold of keys 
-X_0, ... X_n, now instead trust threshold of keys Y_0, ... Y_n.  Rotation of a 
-key may be performed any number of times, transferring trust from X to Y, then 
-from Y to Z, etc. Trust can even be transfered back from Z to X, allowing a key
+Conceptually, the rotation process says if you trusted threshold of keys
+X_0, ... X_n, now instead trust threshold of keys Y_0, ... Y_n.  Rotation of a
+key may be performed any number of times, transferring trust from X to Y, then
+from Y to Z, etc. Trust can even be transferred back from Z to X, allowing a key
 to be added to a role, then later removed.
 
 The mechanism in this TAP has an additional use case: if a rotation
 to a null key is detected, it causes the role to no longer be trusted.  
 A role could use a rotation to a null key if they suspect a compromised key
-(a lost hard drive, system breach, etc). The role is able to create a 
-rotation to null without the help of the delegator, so they are able to 
+(a lost hard drive, system breach, etc). The role is able to create a
+rotation to null without the help of the delegator, so they are able to
 explicitly revoke trust in the role immediately, improving response time
 to a key compromise. A rotation to a null key revokes trust in the role,
 not specific keys, so all keys associated with the role will be invalid
-after a rotation to null. The client will detect a rotation to a null key 
-and treat it as if the delegation was missing a key. The rest of the 
+after a rotation to null. The client will detect a rotation to a null key
+and treat it as if the delegation was missing a key. The rest of the
 delegator's file would still be valid.
 
 The delegator is able to recover from a rotation to null by delegating
 to a new role. The role that has been self revoked can no longer be used.
 Additionally, a delegator can overrule a rotate file by delegating to a
 new role. This ensures that the delegator still has the root of trust,
-but allows the role to act independently.
+but allows the role to act independently. The exception to this is the roles
+defined in the TUF spec (timestamp, snapshot, etc). These roles cannot be
+delegated to a different rolename, so the root role can delegate to the same
+role with a different key to recover from a rotate to null. The root role
+is responsible for ensuring that the current chain of trust is valid
+(this process is described in detail below).
 
 
 # Motivation
 
 TUF supports key rotation for the root keys using an ad hoc way.
-Several use cases can benefit from a generalised mechanism:
+Several use cases can benefit from a generalized mechanism:
 
 
 ## Self-maintaining *project* role
@@ -65,8 +70,8 @@ delegated to.  This project role gives persons with access to it elevated
 privileges, and needs intervention from a higher level of delegations if
 it needs to be rotated or revoked.
 
-With TAP 8, the delegation can be assigned to a role (that contains a set 
-of keys and a threshold value).  Developers could then collectively sign 
+With TAP 8, the delegation can be assigned to a role (that contains a set
+of keys and a threshold value).  Developers could then collectively sign
 rotation metadata to change the set of keys and update the set of developers
 as people enter or leave the project. If the project role had a single key,
 this key could be rotated to ensure only the current developers have access.
@@ -115,13 +120,13 @@ When the root keys delegate trust to a role t for all names, this can be
 used to delegate some names to role d, etc.  When the person who owns
 role d wants to renew their key, they have until now had to ask the holder of
 role t to delegate to the new keyset d'. If one of role d's keys is
-compromised, they have to wait for role t to replace the key with a new, 
+compromised, they have to wait for role t to replace the key with a new,
 trusted key.
 
 With this proposal, the owner of role d can renew their own key, and also
 revoke their key without relying on the delegator.  This will improve
-response time to key compromises and allow keys to be rotated more 
-reguarly.  Combined with multi-role delegations this allows
+response time to key compromises and allow keys to be rotated more
+regularly.  Combined with multi-role delegations this allows
 project teams to shrink and grow without delegation to a project key.
 
 TUF already contains a key rotation mechanism, which is only specified
@@ -157,8 +162,8 @@ signatures part as in tuf spec, not shown here):
 Where ROLE, KEYID, KEY, and THRESHOLD are as defined in the original
 tuf spec.  The value of ROLE has to be the same as the role for the
 delegation.  The value of THRESHOLD is its new value.  PREV_FILENAME is
-the name of the previous rotate file in the chain, or the empty string if this is 
-the first rotate file for this role.  The keys specify the new valid keys 
+the name of the previous rotate file in the chain, or the empty string if this is
+the first rotate file for this role.  The keys specify the new valid keys
 and associated key ids (which may be a subset or superset of
 the old ones).  A rotate file does _not_ contain an expiration date,
 it is meant to be signed once and never modified.  The rotate
@@ -176,27 +181,32 @@ signed with her old key.  She signs her targets file with the new key,
 and uploads both the rotate file and the freshly signed targets file to
 the repository.
 
-The first filename suffix, refered as `ID` above and below, is the hex
+The first filename suffix, referred as `ID` above and below, is the hex
 representation of the SHA256 hash of the concatenation (using "." as
 separator) of the KEYIDs (in ascending lexical order), and the old
 threshold value, encoded decimal as ASCII (0x31 for 1, 0x32 for 2,
 0x31 0x30 for 10).
 
-The second suffix, refered to as 'PREV' is a SHA256 hash of the previous
-rotate file, or the empty string if there is no previous rotate file. 
+The second suffix, referred to as 'PREV' is a SHA256 hash of the previous
+rotate file, or the empty string if there is no previous rotate file.
 This prevents rotation cycles.
+
+The existing delegation to Alice's old key is still valid. If the delegation
+is changed to include her new key, it will also be valid. The client uses
+whichever key is delegated to to find the current chain of trust, then
+follow that chain to the last rotate file to find the current trusted key.
 
 ## Client workflow
 
 A client who wants to install foo now fetches Alice's targets file, and
-during verification looks for a file named `foo.rotate.ID.PREV` in the 
+during verification looks for a file named `foo.rotate.ID.PREV` in the
 rotate folder, ID and PREV are explained above using Alice's old keyid.  
-The client sees the file, fetches 
+The client sees the file, fetches
 it and verifies this rotate file using the public key from the delegation.  
-The client then looks for a rotate file with the new keyid, repeating until 
-there is no matching rotate file to ensure up to date key information. This 
-establishes trust in Alice's new key, and the client can now verify the 
-signature of Alice's targets file using the new key.  If key data is missing 
+The client then looks for a rotate file with the new keyid, repeating until
+there is no matching rotate file to ensure up to date key information. This
+establishes trust in Alice's new key, and the client can now verify the
+signature of Alice's targets file using the new key.  If key data is missing
 or there is a rotation to null the targets file is invalid.
 
 ## Timestamp and snapshot rotation
@@ -205,13 +215,17 @@ Timestamp and snapshot key rotation.  These keys can rotate as
 well, leading to ROLE.rotate.ID.PREV files, where ID and PREV are as described above.
 The value of T is the ASCII encoded old threshold value.  Each file is
 signed by a quorum of old keys, and contains the new keys.  A client
-can fetch the actual data, timestamp, and verify it.  During verification, 
+can fetch the actual data, timestamp, and verify it.  During verification,
 the client needs to fetch the ROLE.rotate.ID.PREV file
 where ID is as described above using the timestamp keyid, either from
-the root file or locally cached and PREV is as described using the previous 
+the root file or locally cached and PREV is as described using the previous
 timestamp rotate file or null.  If the timestamp key is renewed by
 the root, all timestamp.rotate files can be safely removed from the
 repository.
+
+The root role should ensure that all previous rotate files are removed when
+it delegates to a new chain of trust. This ensures that the client sees a
+consistent set of rotate files and is able to follow the chain of trust.
 
 ## Interoperability with TAP 3 (multi-role delegations)
 
@@ -229,15 +243,15 @@ The new targets file foo is then signed by a new threshold (again 2) of
 Alice, Bob, Charlie, and Dan to complete the rotation.
 
 Let's assume Bob and Dan signed foo.  A client which encounters a
-delegation to foo first looks for a foo.rotate.ID.PREV file with the 
-keyids and threshold specified in the delegation file and an inital 
-value of null for the previous rotate file.  If this file exists and is 
+delegation to foo first looks for a foo.rotate.ID.PREV file with the
+keyids and threshold specified in the delegation file and an initial
+value of null for the previous rotate file.  If this file exists and is
 properly signed by Alice and Bob, the client uses it to fetch new keys.  
 The client can then verify foo using Bob's and Dan's signature.
 
 When Evelyn joins, and the threshold is increased to 3,
 foo.rotate.ID'.PREV' is created (ID' is the SHA256 of the concatenated keyids
-Alice, Bob, Charlie, Dan, and 0x32, PREV' is the SHA256 of the previous 
+Alice, Bob, Charlie, Dan, and 0x32, PREV' is the SHA256 of the previous
 rotate file), which contains Alice, Bob,
 Charlie, Dan, and Evelyn public key, and a threshold value of 3.  This
 is signed with at least 2 keys from Alice, Bob, Charlie, or Dan.
@@ -245,15 +259,16 @@ is signed with at least 2 keys from Alice, Bob, Charlie, or Dan.
 ## Rotation to Null
 
 Clients need to check for rotations to a null key, and any delegation pointing
-to a null rotation is invalid.  The null key is a value This enables a role to explicitly revoke their
-own key(s) by introducing a rotation to null. 
+to a null rotation is invalid.  The null key is a key that contains all 0's.
+This enables a role to explicitly revoke their
+own key(s) by introducing a rotation to null.
 
 The rotate files will be listed in the snapshot metadata and shall be
 downloaded as soon as they are available.
 
 **Prioritizing Self Revocation**
-Rotation files are immutable unless replaced with a revocation (rotate 
-to null).  This is the only case in which they can be replaced or 
+Rotation files are immutable unless replaced with a revocation (rotate
+to null).  This is the only case in which they can be replaced or
 modified.  If a client wants to rotate to a different
 key, without having access to their currently delegated private key,
 this requires a key revocation by the person one higher in the
@@ -282,7 +297,7 @@ the key. The role will be invalid until it is re-delegated to.
 
 Intentionally rotating to null enables a repository, a
 project, and individuals to explicitly revoke their key material
-themselves.  An individual whose key is compromised can introduce 
+themselves.  An individual whose key is compromised can introduce
 a rotation to null, and all delegations to them will be invalid.
 
 For mitigation of private key compromises, rotation can be used if and
@@ -312,7 +327,7 @@ even more unlikely.
 
 # Backwards compatibility
 
-TAP 8 is not backwards compatible since clients have to download and 
+TAP 8 is not backwards compatible since clients have to download and
 verify the rotation chain.
 
 # Augmented Reference Implementation

--- a/tap8.md
+++ b/tap8.md
@@ -85,20 +85,17 @@ In addition, this mechanism could be used to give each developer their own
 key, and rotate these keys in and out without going through the delegator.
 
 
-## Root key rotation
+## Why root key rotation is not supported
 
 TAP 8 provides a methodology for key rotations for roles other than root,
 leaving the root rotation mechanism in place.
 
 Root key rotation cannot use the TAP 8 rotation mechanism to establish a
-trusted key. The different root metadata versions build a chain of trust,
-where if the initial root is trusted (TOFU or by being distributed over a
-trusted channel), following the chain of key rotations leads to verified
-keys for the current root metadata. The root metadata contains
-additional information, like the spec-version that needs to be seen for
-each version of the file. This means that even if the keys are not
-changed, a client must download every version of the root metadata in
-order to follow the chain of delegations.
+trusted key. The root metadata file contains information, like the
+spec-version, that needs to be seen for each version of the file. This
+means that even if the keys are not changed, a client must download every
+version of the root metadata in order to ensure the client spec-version is
+in line with the server spec-version.
 
 ## Auto-rotation timestamp role
 
@@ -127,7 +124,7 @@ is rooted in a quorum of root keys, which delegate trust to other roles.
 When the root keys delegate trust to a role t for all names, this can be
 used to delegate some names to role d, etc.  When the person who owns
 role d wants to renew their key, they have until now had to ask the holder of
-role t to delegate to the new keyset d'. If one of role ds keys is
+role t to delegate to the new keyset e. If one of role d's keys is
 compromised, they have to wait for role t to replace the key with a new,
 trusted key.
 

--- a/tap8.md
+++ b/tap8.md
@@ -237,7 +237,7 @@ to add a keyid from Dan to the project, they create a foo.rotate.ID.PREV
 file, where ID is as described above (the SHA256 of the concatenated
 key ids of Alice, Bob, Charlie, and the character 0x32). This
 contains all four keys, and a new threshold (again 2).  PREV is the
-SHA256 of null as this is the first rotation for foo.  The file
+SHA256 of "" as this is the first rotation for foo.  The file
 foo.rotate.ID.PREV is signed by at least 2 keyids of Alice, Bob, and Charlie.
 The new targets file foo is then signed by a new threshold (again 2) of
 Alice, Bob, Charlie, and Dan to complete the rotation.
@@ -245,7 +245,7 @@ Alice, Bob, Charlie, and Dan to complete the rotation.
 Let's assume Bob and Dan signed foo.  A client which encounters a
 delegation to foo first looks for a foo.rotate.ID.PREV file with the
 keyids and threshold specified in the delegation file and an initial
-value of null for the previous rotate file.  If this file exists and is
+value of "" for the previous rotate file.  If this file exists and is
 properly signed by Alice and Bob, the client uses it to fetch new keys.  
 The client can then verify foo using Bob's and Dan's signature.
 
@@ -259,8 +259,8 @@ is signed with at least 2 keys from Alice, Bob, Charlie, or Dan.
 ## Rotation to Null
 
 Clients need to check for rotations to a null key, and any delegation pointing
-to a null rotation is invalid.  The null key is a key that contains all 0's.
-This enables a role to explicitly revoke their
+to a null rotation is invalid.  The null key is a hard coded value used across
+tuf implementations. This enables a role to explicitly revoke their
 own key(s) by introducing a rotation to null.
 
 The rotate files will be listed in the snapshot metadata and shall be

--- a/tap8.md
+++ b/tap8.md
@@ -2,7 +2,7 @@
 * Title: Key rotation and explicit self-revocation
 * Version: 2
 * Last-Modified: 19-Sep-2018
-* Author: Hannes Mehnert, Justin Cappos
+* Author: Hannes Mehnert, Justin Cappos, Marina Moore
 * Status: Draft
 * Content-Type: text/markdown
 * Created: 10-May-2017
@@ -11,7 +11,7 @@
 # Abstract
 
 TAP 8 allows a role to change or revoke their key without requiring changes from
-parties that delegate to that role.  This involves a role rotating trust from their 
+parties that delegate to that role.  This involves a role rotating trust from their
 current key(s) to a new key or keys.
 For example, if a project role has a single key, the owner of this key could
 create a rotate file to transfer trust for that role to a new key. The old key
@@ -22,6 +22,10 @@ list of trusted keys with an associated threshold during the rotate process.
 Performing a key rotation does not require parties that delegated trust to the
 role to change their delegation. Roles are thus able to rotate to new trusted
 keys independently, allowing keys to be changed more often.
+
+The key rotation mechanism is designed to be used by all roles except the
+root role. The root role will continue to use the root metadata to establish
+a trusted root key.
 
 Conceptually, the rotation process says if you trusted threshold of keys
 X_0, ... X_n, now instead trust threshold of keys Y_0, ... Y_n.  Rotation of a
@@ -81,18 +85,20 @@ In addition, this mechanism could be used to give each developer their own
 key, and rotate these keys in and out without going through the delegator.
 
 
-## Clarify root key rotation
+## Root key rotation
 
-The different root metadata versions build a chain of trust, where if
-the initial root is trusted (TOFU or by being distributed over a trusted
-channel), following the chain of key rotations leads to verified keys
-for the current root metadata.  This means that even if the keys are not
-changed, a client must download every version of the root metadata in
-order to follow the chain of delegations.  The root metadata contains
+TAP 8 provides a methodology for key rotations for roles other than root,
+leaving the root rotation mechanism in place.
+
+Root key rotation cannot use the TAP 8 rotation mechanism to establish a
+trusted key. The different root metadata versions build a chain of trust,
+where if the initial root is trusted (TOFU or by being distributed over a
+trusted channel), following the chain of key rotations leads to verified
+keys for the current root metadata. The root metadata contains
 additional information, like the spec-version that needs to be seen for
-each version of the file.
-
-TAP 8 provides a methodology for key rotations for other roles as well.
+each version of the file. This means that even if the keys are not
+changed, a client must download every version of the root metadata in
+order to follow the chain of delegations.
 
 ## Auto-rotation timestamp role
 
@@ -121,7 +127,7 @@ is rooted in a quorum of root keys, which delegate trust to other roles.
 When the root keys delegate trust to a role t for all names, this can be
 used to delegate some names to role d, etc.  When the person who owns
 role d wants to renew their key, they have until now had to ask the holder of
-role t to delegate to the new keyset d'. If one of role d's keys is
+role t to delegate to the new keyset d'. If one of role ds keys is
 compromised, they have to wait for role t to replace the key with a new,
 trusted key.
 
@@ -261,7 +267,7 @@ is signed with at least 2 keys from Alice, Bob, Charlie, or Dan.
 ## Rotation to Null
 
 Clients need to check for rotations to a null key, and any delegation pointing
-to a null rotation is invalid.  The null key is a hard coded value used across
+to a rotation to a null key is invalid.  The null key is a hard coded value used across
 tuf implementations. This enables a role to explicitly revoke their
 own key(s) by introducing a rotation to null.
 
@@ -292,7 +298,7 @@ provide a simple mechanism extending and shrinking projects by
 themselves without an individual with elevated privileges, but based
 on a threshold of signatures.
 
-Clients need to take care to check for null rotations (rotate
+Clients need to take care to check for rotation to a null key (rotate
 files that contain a null key).  This shall be handled in the
 same manner as an invalid metadata signature on by the role possessing
 the key. The role will be invalid until it is re-delegated to.

--- a/tap8.md
+++ b/tap8.md
@@ -58,12 +58,11 @@ the initial root is trusted (TOFU or by being distributed over a trusted
 channel), following the chain of key rotations leads to verified keys
 for the current root metadata.  This means that even if the keys are not
 changed, a client must download every version of the root metadata in
-order to follow the chain of delegations.  This could be an efficiency
-concern in some situations.
+order to follow the chain of delegations.  The root metadata contains
+additional information, like the spec-version that needs to be seen for
+each version of the file.
 
-TAP 8 provides a unified methodology for key rotations.  Using this
-mechanism, only those root files in which new root keys are added or
-old ones are removed need to be fetched and verified.
+TAP 8 provides a methodology for key rotations for other roles as well.
 
 ## Auto-rotation timestamp role
 
@@ -99,8 +98,8 @@ revoke their key.  Combined with multi-role delegations this allows
 project teams to shrink and grow without delegation to a project key.
 
 TUF already contains a key rotation mechanism, which is only specified
-and used for the root file.  This proposal generalises the rotation
-mechanism to all delegations, and extends it with self-revocation.
+and used for the root file.  This proposal allows the rotation
+mechanism to be used by other delegations, and extends it with self-revocation.
 
 
 # Specification
@@ -162,9 +161,9 @@ establishes trust in Alice's new key, and the client can now verify the
 signature of Alice's targets file using the new key.  If key data is missing 
 or there is a cycle in the rotations the targets file is invalid.
 
-## Root rotation
+## Timestamp and snapshot rotation
 
-Root, timestamp and snapshot key rotation.  These keys can rotate as
+Timestamp and snapshot key rotation.  These keys can rotate as
 well, leading to ROLE.rotate.ID files, where ID is as described above.
 The value of T is the ASCII encoded old threshold value.  Each file is
 signed by a quorum of old keys, and contains the new keys.  A client
@@ -174,15 +173,6 @@ where ID is as described above using the timestamp keyid, either from
 the root file or locally cached.  If the timestamp key is renewed by
 the root, all timestamp.rotate files can be safely removed from the
 repository.
-
-Initial root key provisioning.  The root keys are no longer part of the
-root files, but initially provided via other means (e.g. manually, via
-an URL, or within the repository as root0).  This keeps the root files
-more concise.  When root keys are rotated, a root.rotate.ID is
-generated, containing the new root keys, and signed with (a threshold
-of) the old root keys.  A client downloads the root file, and the chain
-of rotations, starting from its trusted root keys.
-
 
 ## Interoperability with TAP 3 (multi-role delegations)
 
@@ -285,9 +275,8 @@ roles do not contain any "." - which is used as separator.
 
 # Backwards compatibility
 
-TAP 8 is not backwards compatible since the root keys are no longer part
-of the root file.  Furthermore, clients have to download and verify the
-rotation chain.
+TAP 8 is not backwards compatible since clients have to download and 
+verify the rotation chain.
 
 # Augmented Reference Implementation
 

--- a/tap8.md
+++ b/tap8.md
@@ -216,8 +216,9 @@ warn the user.
 The rotate files should be listed in the snapshot metadata and should be
 downloaded as soon as they are available.
 
-Rotation files are immutable and should not be replaced or modified
-under any circumstances.  If a client wants to rotate to a different
+Rotation files are immutable unless replaced with a revocation (rotate 
+to null).  This is the only case in which they can be replaced or 
+modified.  If a client wants to rotate to a different
 key, without having access to their currently delegated private key,
 this requires a key revocation by the person one higher in the
 delegation chain.

--- a/tap8.md
+++ b/tap8.md
@@ -140,7 +140,7 @@ signatures part as in tuf spec, not shown here):
 ```python
 {
     "_type" : "rotate" ,
-    "previous" : PREV_HASH
+    "previous" : PREV_FILENAME
     "role" : ROLE,
     "keys" : {
         KEYID : KEY
@@ -152,9 +152,9 @@ signatures part as in tuf spec, not shown here):
 
 Where ROLE, KEYID, KEY, and THRESHOLD are as defined in the original
 tuf spec.  The value of ROLE has to be the same as the role for the
-delegation.  The value of THRESHOLD is its new value.  PREV_HASH is
-the sha256 hash of the previous rotate file, or null if this is the
-first rotate file.  The keyids
+delegation.  The value of THRESHOLD is its new value.  PREV_FILENAME is
+the name of the previous rotate file in the chain, or null if this is 
+the first rotate file for this role.  The keyids
 specify the new valid key ids (which may be a subset or superset of
 the old ones).  A rotate file does _not_ contain an expiration date,
 it is meant to be signed once and never modified.  The rotate

--- a/tap8.md
+++ b/tap8.md
@@ -134,6 +134,9 @@ the old ones).  A rotate file does _not_ contain an expiration date,
 it is meant to be signed once and never modified.  The rotate
 file has to be signed with an old threshold of old keys.
 
+The rotate file will go into a repository in a 'rotate' folder that contains
+all rotate files for the repository.
+
 Let's consider a motivating example, project foo is delegated to Alice.
 Alice's computer with the key material got stolen, but the disk was
 encrypted.  To be safe, she decides to get her key from her backup and
@@ -156,8 +159,9 @@ rotation cycles.
 ## Client workflow
 
 A client who wants to install foo now fetches Alice's targets file, and
-during verification looks for a file named `foo.rotate.ID.PREV`, ID and PREV 
-are explained above using Alice's old keyid.  The client sees the file, fetches 
+during verification looks for a file named `foo.rotate.ID.PREV` in the 
+rotate folder, ID and PREV are explained above using Alice's old keyid.  
+The client sees the file, fetches 
 it and verifies this rotate file using the public key from the delegation.  
 The client then looks for a rotate file with the new keyid, repeating until 
 there is no matching rotate file to ensure up to date key information. This 

--- a/tap8.md
+++ b/tap8.md
@@ -145,7 +145,6 @@ signatures part as in tuf spec, not shown here):
     "keys" : {
         KEYID : KEY
         , ... } ,
-    "keyids" : [ KEYID , ... ] ,
     "threshold" : THRESHOLD }
 }
 ```
@@ -154,8 +153,8 @@ Where ROLE, KEYID, KEY, and THRESHOLD are as defined in the original
 tuf spec.  The value of ROLE has to be the same as the role for the
 delegation.  The value of THRESHOLD is its new value.  PREV_FILENAME is
 the name of the previous rotate file in the chain, or null if this is 
-the first rotate file for this role.  The keyids
-specify the new valid key ids (which may be a subset or superset of
+the first rotate file for this role.  The keys specify the new valid keys 
+and associated key ids (which may be a subset or superset of
 the old ones).  A rotate file does _not_ contain an expiration date,
 it is meant to be signed once and never modified.  The rotate
 file has to be signed with an old threshold of old keys.

--- a/tap8.md
+++ b/tap8.md
@@ -10,7 +10,9 @@
 
 # Abstract
 
-TAP 8 allows roles to rotate trust from their current keys to a new key or keys.
+TAP 8 allows a role to change or revoke their key without requiring changes from
+parties that delegate to that role.  This involves a role rotating trust from their 
+current key(s) to a new key or keys.
 For example, if a project role has a single key, the owner of this key could
 create a rotate file to transfer trust for that role to a new key. The old key
 would no longer be trusted and the new key would be used for all subsequent

--- a/tap8.md
+++ b/tap8.md
@@ -10,22 +10,35 @@
 
 # Abstract
 
-TAP 8 generalises the mechanism of key rotation.  Rotation is the process by
-which a role uses their old key or set of keys to invalidate their old key set 
-and transfer trust in the old key set to a new key set with an associated 
-threshold.  Performing a key rotation does not require parties that delegated 
-trust to the old key set to change their delegation to the new key set.  
+TAP 8 allows roles to rotate trust from their current keys to a new key or keys.
+For example, if a project role has a single key, the owner of this key could
+create a rotate file to transfer trust for that role to a new key. The old key
+would no longer be trusted and the new key would be used for all subsequent
+signatures by the project role. The rotation mechanism is extended for use
+by roles that have multiple trusted keys by allowing the role to define a new
+list of trusted keys with an associated threshold during the rotate process.
+Performing a key rotation does not require parties that delegated trust to the
+role to change their delegation. Roles are thus able to rotate to new trusted
+keys independently, allowing keys to be changed more often.
+
 Conceptually, the rotation process says if you trusted threshold of keys 
 X_0, ... X_n, now instead trust threshold of keys Y_0, ... Y_n.  Rotation of a 
 key may be performed any number of times, transferring trust from X to Y, then 
-from Y to Z, etc.
+from Y to Z, etc. Trust can even be transfered back from Z to X, allowing a key
+to be added to a role, then later removed.
 
 The mechanism in this TAP has an additional use case:  if a rotation
-to a null key is detected, it causes a key revocation.  Note, this is 
-handled the same as a delegation to a missing key
-and does not invalidate the delegator's entire file.  This use of rotate
-revocation allows a role to explicitly revoke their own key for all future
-actions (by rotating to null).
+to a null key is detected, it causes the role to no longer be trusted.  
+A role could use a rotation to a null key if they suspect a compromised key
+(a lost hard drive, system breach, etc). The role is able to create a 
+rotation to null without the help of the delegator, so they are able to 
+explicitly revoke trust in the role immediately, improving response time
+to a key compromise. A rotation to a null key revokes trust in the role,
+not specific keys, so all keys associated with the role will be invalid
+after a rotation to null. The client will detect a rotation to a null key 
+and treat it as if the delegation was missing a key. The rest of the 
+delegator's file would still be valid.
+
 
 # Motivation
 
@@ -35,20 +48,24 @@ Several use cases can benefit from a generalised mechanism:
 
 ## Self-maintaining *project* role
 
-It is common to have a single *project key* delegated from the targets
+It is common to have a single *project role* delegated from the targets
 role so that the members of the project can change without the
-delegations to the project being replaced.  The *project key*
+delegations to the project being replaced.  The *project role*
 represents a single point of failure / compromise.  (Some projects may
 prefer a quorum of developers instead, but this requires
 delegations to be redone whenever this quorum changed.) Adding and
-removing delegations of a project often uses the project key which is
-delegated to.  This project key gives persons with access to it elevated
+removing delegations of a project often uses the project role's key which is
+delegated to.  This project role gives persons with access to it elevated
 privileges, and needs intervention from a higher level of delegations if
 it needs to be rotated or revoked.
 
-With TAP 8, the delegation can be initially to a set of keys
-and a threshold value.  Developers could then collectively sign rotation
-metadata to change the set of keys and update the set of developers.
+With TAP 8, the delegation can be assigned to a role (that contains a set 
+of keys and a threshold value).  Developers could then collectively sign 
+rotation metadata to change the set of keys and update the set of developers
+as people enter or leave the project. If the project role had a single key,
+this key could be rotated to ensure only the current developers have access.
+In addition, this mechanism could be used to give each developer their own
+key, and rotate these keys in and out without going through the delegator.
 
 
 ## Clarify root key rotation
@@ -86,15 +103,20 @@ thus is not intended to be handled by this TAP.
 
 # Rationale
 
-TUF is a framework for securing software update systems.  The trust
+TUF is a framework for securing software update systems that is designed
+to maintain trust in the system through key compromises. The trust
 is rooted in a quorum of root keys, which delegate trust to other roles.
 When the root keys delegate trust to a role t for all names, this can be
 used to delegate some names to role d, etc.  When the person who owns
-role d wants to renew their key, they have until now to ask the holder of
-role t to delegate to the new keyset d'.
+role d wants to renew their key, they have until now had to ask the holder of
+role t to delegate to the new keyset d'. If one of role d's keys is
+compromised, they have to wait for role t to replace the key with a new, 
+trusted key.
 
 With this proposal, the owner of role d can renew their own key, and also
-revoke their key.  Combined with multi-role delegations this allows
+revoke their key without relying on the delegator.  This will improve
+response time to key compromises and allow keys to be rotated more 
+reguarly.  Combined with multi-role delegations this allows
 project teams to shrink and grow without delegation to a project key.
 
 TUF already contains a key rotation mechanism, which is only specified
@@ -105,7 +127,8 @@ mechanism to be used by other delegations, and extends it with self-revocation.
 # Specification
 
 To support key rotation, the new metadata type `rotate` is
-introduced, which contains the new public key(s), the threshold, and is
+introduced, which contains the new public key(s), the threshold, a hash
+of the previous rotate file in the chain, and is
 signed by a threshold of old public keys.   The intuition is while
 delegations keep intact, the targets can rotate keys, shrink or grow.
 
@@ -117,6 +140,7 @@ signatures part as in tuf spec, not shown here):
 ```python
 {
     "_type" : "rotate" ,
+    "previous" : PREV_HASH
     "role" : ROLE,
     "keys" : {
         KEYID : KEY
@@ -128,7 +152,9 @@ signatures part as in tuf spec, not shown here):
 
 Where ROLE, KEYID, KEY, and THRESHOLD are as defined in the original
 tuf spec.  The value of ROLE has to be the same as the role for the
-delegation.  The value of THRESHOLD is its new value.  The keyids
+delegation.  The value of THRESHOLD is its new value.  PREV_HASH is
+the sha256 hash of the previous rotate file, or null if this is the
+first rotate file.  The keyids
 specify the new valid key ids (which may be a subset or superset of
 the old ones).  A rotate file does _not_ contain an expiration date,
 it is meant to be signed once and never modified.  The rotate
@@ -153,8 +179,8 @@ threshold value, encoded decimal as ASCII (0x31 for 1, 0x32 for 2,
 0x31 0x30 for 10).
 
 The second suffix, refered to as 'PREV' is a SHA256 hash of the previous
-rotate file, or of null if there is no previous rotate file. This prevents
-rotation cycles.
+rotate file, or of null if there is no previous rotate file (the same as 
+PREV_HASH in the file). This prevents rotation cycles.
 
 ## Client workflow
 
@@ -206,21 +232,22 @@ properly signed by Alice and Bob, the client uses it to fetch new keys.
 The client can then verify foo using Bob's and Dan's signature.
 
 When Evelyn joins, and the threshold is increased to 3,
-foo.rotate.ID.PREV' is created (ID' is the SHA256 of the concatenated keyids
-Alice, Bob, Charlie, Dan, and 0x32, PREV is the SHA256 of the previous 
+foo.rotate.ID'.PREV' is created (ID' is the SHA256 of the concatenated keyids
+Alice, Bob, Charlie, Dan, and 0x32, PREV' is the SHA256 of the previous 
 rotate file), which contains Alice, Bob,
 Charlie, Dan, and Evelyn public key, and a threshold value of 3.  This
 is signed with at least 2 keys from Alice, Bob, Charlie, or Dan.
 
-## Key Revocation
+## Rotation to Null
 
 Clients need to check for rotations to a null key, and any delegation pointing
 to a null rotation is invalid.  This enables a role to explicitly revoke their
 own key(s) by introducing a rotation to null. 
 
-The rotate files should be listed in the snapshot metadata and should be
+The rotate files will be listed in the snapshot metadata and shall be
 downloaded as soon as they are available.
 
+**Prioritizing Self Revocation**
 Rotation files are immutable unless replaced with a revocation (rotate 
 to null).  This is the only case in which they can be replaced or 
 modified.  If a client wants to rotate to a different
@@ -244,10 +271,10 @@ provide a simple mechanism extending and shrinking projects by
 themselves without an individual with elevated privileges, but based
 on a threshold of signatures.
 
-Clients need to take care to check for null rotations where rotate
-files contain a null key.  This should be handled in the
+Clients need to take care to check for null rotations (rotate
+files that contain a null key).  This shall be handled in the
 same manner as an invalid metadata signature on by the role possessing
-the key.
+the key. The role will be invalid until it is re-delegated to.
 
 Intentionally rotating to null enables a repository, a
 project, and individuals to explicitly revoke their key material


### PR DESCRIPTION
Based on discussion in the issue, I made a few proposed changes to the TAP 8 spec. These are:

- The root role does not use the TAP 8 rotation mechanism, but continues to use the ad hoc rotation.
- Rotate files can be replaced by a revocation, but nothing else.
- Each rotate file points to the previous rotate file to prevent accidental rotation cycles. Key revocation is done through a rotation to a null key.
- Repositories contain a rotate folder that holds all rotate files.