### PR TITLE
tap*: Use TUF-Version header as spec reference

### DIFF
--- a/tap1.md
+++ b/tap1.md
@@ -105,7 +105,7 @@ The format of a TAP is specified with a Content-Type header. The acceptable valu
 
 The Created header records the date that the TAP was assigned a number, while Post-History is used to record the dates of when new versions of the TAP are posted to the TUF mailing list.  Both headers should be in dd-mmm-yyyy format, e.g. 14-Aug-2001.
 
-TAPs will typically have a TUF-Version header which indicates the version of TUF that the feature will be released with. TAPs without a TUF-Version header indicate interoperability standards that will initially be supported through external libraries and tools, and then supplemented by a later TAP to add support to the Reference Implementation.
+TAPs will typically have a TUF-Version header which indicates the version of TUF that the feature will be released with. TAPs that refer to processes or recommendations do not require a TUF-Version header.
 
 TAPs may have a Requires header, indicating the TAP numbers that this TAP depends on.
 

--- a/tap10.md
+++ b/tap10.md
@@ -7,6 +7,7 @@
 * Content-Type: text/markdown
 * Created: 19-July-2017
 * Post-History: 25-July-2017
+* TUF-Version: 1.0.0
 
 # Abstract
 

--- a/tap3.md
+++ b/tap3.md
@@ -7,6 +7,7 @@
 * Status: Accepted
 * Content-Type: text/markdown
 * Created: 16-Sep-2016
+* TUF-Version: 1.0.0
 
 # Abstract
 

--- a/tap4.md
+++ b/tap4.md
@@ -8,6 +8,7 @@
 * Content-Type: text/markdown
 * Requires: [TAP 5](tap5.md)
 * Created: 09-Sep-2016
+* TUF-Version: 1.0.0
 
 # Abstract
 This TAP offers guidance for conducting a secure search for particular targets

--- a/tap6.md
+++ b/tap6.md
@@ -7,6 +7,7 @@
 * Content-Type: text/markdown
 * Created: 19-Jan-2017
 * Post-History: 06-Oct-2016
+* TUF-Version: 1.0.0
 
 # Abstract
 

--- a/tap9.md
+++ b/tap9.md
@@ -6,6 +6,7 @@
 * Status: Accepted
 * Content-Type: text/markdown
 * Created: 20-Jan-2017
+* TUF-Version: 1.0.0
 
 # Abstract
 


### PR DESCRIPTION
The TUF-Version header is not utilized as of now. Instead of leaving it
as an unused appendix, utilize it to reference to the version of the
specification that integrates this TAP.

In addition, update all taps that should have a TUF-Version header in
them.