### PR TITLE
Suggested changes to TAP 11 and POUF 1

### DIFF
--- a/POUFs/reference-POUF/pouf1.md
+++ b/POUFs/reference-POUF/pouf1.md
@@ -165,7 +165,7 @@ The "signed" portion of root.json is as follows:
              , ... }
        }
 
-   SPEC_VERSION is the version number of the specification using semantic versioning.
+   SPEC_VERSION is the version number of the specification using [semantic versioning](https://semver.org/spec/v2.0.0.html).
    For purposes of ensuring the spec_version matches during an update, the reference
    implementation considers all  spec_version's with the same major version number to
    be a match.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 * [TAP 6: Include specification version in metadata](tap6.md)
 * [TAP 9: Mandatory metadata signing schemes](tap9.md)
 * [TAP 10: Remove native support for compressed metadata](tap10.md)
+* [TAP 11: Using POUFs for Interoperability](tap11.md)
 
 ## Draft
 
 * [TAP 5: Setting URLs for roles in the root metadata file](tap5.md)
 * [TAP 8: Key rotation and explicit self-revocation](tap8.md)
-* [TAP 11: Using POUFs for Interoperability](tap11.md)
 * [TAP 12: Improving keyid flexibility](tap12.md)
 
 ## Rejected

--- a/tap11.md
+++ b/tap11.md
@@ -1,9 +1,9 @@
 * TAP: 11
 * Title: Using POUFs for Interoperability
 * Version: 1
-* Last-Modified: 06-May-2020
+* Last-Modified: 17-Jul-2020
 * Author: Marina Moore, Santiago Torres, Trishank Kuppusamy, Sebastien Awwad, Justin Cappos
-* Status: Draft
+* Status: Accepted
 * Content-Type: text/markdown
 * Created: 9-November-2018
 

--- a/tap11.md
+++ b/tap11.md
@@ -1,4 +1,4 @@
-* TAP:
+* TAP: 11
 * Title: Using POUFs for Interoperability
 * Version: 1
 * Last-Modified: 26-June-2019
@@ -50,7 +50,7 @@ These statuses are maintained by the POUF author and included in the header of t
 They allow POUFs in all stages to be made available while clarifying which are ready to be implemented.
 
 POUFs may be changed over time to account for changes to the TUF specification, updates to protocols, or other design changes.
-To indicate that a change has occurred, new version numbers should be assigned to the POUF. The version number will be stored in the POUF header as described in {#pouf-format}.
+To indicate that a change has occurred, new version numbers should be assigned to the POUF. The version number will be stored in the POUF header as described in [POUF Format](#pouf-format).
 In order for a POUF implementer to know if their implementation needs to be updated, any changes that make a POUF not backwards compatible should result in a new version number.
 The format and management of version numbers is left to the POUF author, but standard formats like Semantic Versioning (https://semver.org/) are recommended for clarity and consistency with TUF. In addition, POUF authors may refer to how TUF manages updates to ensure that non backwards compatible POUFs do not interfere with TUF communication.
 
@@ -67,7 +67,7 @@ For example, implementers a and b may implement POUF p1.
 This means that a and b will be able to interoperate, but they will not necessarily be able to interoperate with implementers of POUF p2.
 It is important that implementations list in their documentation the POUF(s) that are supported as well as the version numbers for these POUF(s) so that other implementers looking to interoperate may refer to the relevant POUF.
 
-To ensure that a POUF follows the TUF specification and that it does not introduce new security issues, we recommend a security audit for POUFs as described in {#security-audit}.
+To ensure that a POUF follows the TUF specification and that it does not introduce new security issues, we recommend a security audit for POUFs as described in [Security Audit](#security-audit).
 In addition to checking the POUF against the specification, this audit ensures that the encoding method or design decisions do not introduce ambiguity or an insecure implementation.
 The security audit does not guarantee security, but provides some oversight.
 
@@ -75,7 +75,7 @@ The security audit does not guarantee security, but provides some oversight.
 
 If a POUF author wants their POUF to be publicly accessed and reviewed, it should be stored in a public location that can be accessed by other TUF implementers.
 In addition to storing the current POUF, the author may maintain old versions of the POUF to allow existing implementations to continue to refer to them.
-Old versions will have a unique version number in the header as described in {#pouf-format}, and may additionally be named according to the POUF version.
+Old versions will have a unique version number in the header as described in [POUF Format](#pouf-format), and may additionally be named according to the POUF version.
 For example a POUF repository may contain two documents, POUFNAME-1.md and POUFNAME-2.md, that contain version 1 and 2 of the POUF respectively.
 
 A link to a public POUF can be added to the TAP repository through the pull request process.
@@ -95,7 +95,7 @@ At a minimum, a POUF shall contain the following sections:
   * Title:
   * Version:
   * Last-Modified:
-  * Author: optional list of authors' real names and email addrs
+  * Author: optional list of authors' real names and email addresses
   * Status: Draft / In Use / Obsolete
   * TUF Version Implemented:
   * Content-Type: text/markdown
@@ -117,7 +117,7 @@ At a minimum, a POUF shall contain the following sections:
   If mirrors are supported by the POUF, their format should be described here. Information about how mirrors are used may be included in the Operations section of the POUF.
 
   The canonical json description currently in the TUF specification (under "Document Formats") provides an example of the type definitions required for the Formats section of a POUF.
-* Security Audit: The third party security audit as described in {#security-audit}.
+* Security Audit: The third party security audit as described in [Security Audit](#security-audit).
 
 ## Security Audit
 

--- a/tap11.md
+++ b/tap11.md
@@ -1,7 +1,7 @@
 * TAP: 11
 * Title: Using POUFs for Interoperability
 * Version: 1
-* Last-Modified: 26-June-2019
+* Last-Modified: 06-May-2020
 * Author: Marina Moore, Santiago Torres, Trishank Kuppusamy, Sebastien Awwad, Justin Cappos
 * Status: Draft
 * Content-Type: text/markdown

--- a/tap11.md
+++ b/tap11.md
@@ -98,6 +98,7 @@ At a minimum, a POUF shall contain the following sections:
   * Author: optional list of authors' real names and email addresses
   * Status: Draft / In Use / Obsolete
   * TUF Version Implemented:
+  * Implementation Version(s) Covered: release version information of the implementation versions covered by this Version of the POUF
   * Content-Type: text/markdown
   * Created: date created on, in dd-mmm-yyyy format
 * Abstract: Description of the POUF including an overview of design decisions. If the POUF version has been updated, the changes to the POUF should be described here.

--- a/tap11.md
+++ b/tap11.md
@@ -101,7 +101,7 @@ At a minimum, a POUF shall contain the following sections:
   * Implementation Version(s) Covered: release version information of the implementation versions covered by this Version of the POUF
   * Content-Type: text/markdown
   * Created: date created on, in dd-mmm-yyyy format
-* Abstract: Description of the POUF including an overview of design decisions. If the POUF version has been updated, the changes to the POUF should be described here.
+* Abstract: Description of the POUF including an overview of design decisions. If the POUF version has been updated, a summary of high-level changes to the POUF should be described here.
 * Protocol: The protocol section describes the networking operations of the implementation. This includes the protocol used to transmit data, the location and filenames of any hosted files, and a Message Handler Table. The Message Handler Table will list all messages transmitted by the implementation. Each entry in the Message Handler Table will include the sender, receiver, data, and expected response. All messages in this table must be implemented by anyone using the POUF.
 * Operations: The operations section contains a description of any design elements or features that differ from the TUF specification. This section will describe any optional or additional features that are required for compatibility. The format of data does not need to be described here.
 * Usage: The usage section contains an overview of how data is managed by the implementation. This includes key management, key rotation, server setup, supply chain security, and device registration.
@@ -119,6 +119,7 @@ At a minimum, a POUF shall contain the following sections:
 
   The canonical json description currently in the TUF specification (under "Document Formats") provides an example of the type definitions required for the Formats section of a POUF.
 * Security Audit: The third party security audit as described in [Security Audit](#security-audit).
+* Version History: For versions beyond the initial release this should be a list of changes introduced in each new version of the POUF. This section could also map POUF versions to releases of the implementation.
 
 ## Security Audit
 

--- a/tap11.md
+++ b/tap11.md
@@ -97,7 +97,7 @@ At a minimum, a POUF shall contain the following sections:
   * Last-Modified:
   * Author: optional list of authors' real names and email addresses
   * Status: Draft / In Use / Obsolete
-  * TUF Version Implemented:
+  * TUF Version(s) Implemented: the release version of the TUF specification versions covered by the POUF
   * Implementation Version(s) Covered: release version information of the implementation versions covered by this Version of the POUF
   * Content-Type: text/markdown
   * Created: date created on, in dd-mmm-yyyy format


### PR DESCRIPTION
I was reading about POUF's in TAP 11, which made me want to update POUF 1 to match the current state of the reference implementation. Which further made me want to suggest some changes to TAP 11 to track what I think are useful pieces of information in the POUF.

Changes in the PR include:
* recommend the POUF list version numbers of the implementation which are covered by the POUF
* suggest POUF's include a list of changes across versions
* Update POUF 1 to match the reference implementation, including the TAP 11 suggestions above