### PR TITLE
Assign a TAP number to candidate-keyid-tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * [TAP 5: Setting URLs for roles in the root metadata file](tap5.md)
 * [TAP 8: Key rotation and explicit self-revocation](tap8.md)
 * [TAP 11: Using POUFs for Interoperability](tap11.md)
+* [TAP 12: Improving keyid flexibility](tap12.md)
 
 ## Rejected
 

--- a/tap12.md
+++ b/tap12.md
@@ -1,4 +1,4 @@
-* TAP: TBD
+* TAP: 12
 * Title: Improving keyid flexibility
 * Version: 1.0.0
 * Last-Modified: 09-04-2020


### PR DESCRIPTION
Fixes #114 

Assigns a TAP number to the Draft TAP in accordance with the workflow laid out in [TAP 1](https://github.com/theupdateframework/taps/blob/master/tap1.md).