### PR TITLE
Fix broken links to Diplomat paper

### DIFF
--- a/tap3.md
+++ b/tap3.md
@@ -34,7 +34,7 @@ insufficient to execute arbitrary software attacks.
 
 We introduce this TAP because there is no mechanism in place to support use
 case 1.  TUF uses [prioritized and terminating
-delegations](http://isis.poly.edu/~jcappos/papers/kuppusamy_nsdi_16.pdf) to
+delegations](https://theupdateframework.io/papers/protect-community-repositories-nsdi2016.pdf) to
 search for metadata about a desired target in a controlled manner.
 
 Using multiple delegations, one can delegate the same target to multiple roles,

--- a/tap5.md
+++ b/tap5.md
@@ -36,7 +36,7 @@ hosting and maintaining its own repository.
 Furthermore, suppose that there is group of enterprise users who trust PyPI only
 to install Django packages.
 These users must depend on PyPI administrators to
-[delegate](https://isis.poly.edu/~jcappos/papers/kuppusamy_nsdi_16.pdf)
+[delegate](https://theupdateframework.io/papers/protect-community-repositories-nsdi2016.pdf)
 all Django packages to the correct public keys belonging to the project.
 Unfortunately, if the PyPI administrator keys have been compromised, then
 attackers can replace this delegation, and deceive these unsuspecting users into


### PR DESCRIPTION
Justin Cappos' home space on isis.poly.edu is not resolvable, switch instead
to linking to copies of the paper hosted on theupdateframework.io
