### PR TITLE
Update TAP process to recommend public domain or CC-By for TAPs

### DIFF
--- a/tap1-1.dot
+++ b/tap1-1.dot
@@ -1,4 +1,4 @@
-// Converted into a png with: dot -Tpng -o tap1-flow.png tap1-flow.dot
+// Converted into a png with: dot -Tpng -o tap1-1.png tap1-1.dot
 digraph {
     node[shape=box, style=rounded]
 

--- a/tap1.md
+++ b/tap1.md
@@ -1,7 +1,7 @@
 * TAP: 1
 * Title: TAP Purpose and Guidelines
 * Version: 2
-* Last-Modified: 28-Jul-2020
+* Last-Modified: 30-Nov-2020
 * Author: Trishank Karthik Kuppusamy, Lois Anne DeLong, Justin Cappos, Joshua Lock
 * Status: Active
 * Content-Type: text/markdown
@@ -111,7 +111,7 @@ Each TAP SHOULD have the following parts:
 
 8. *Augmented Reference Implementation* -- The augmented reference implementation must be completed before any TAP is given "Final" status, but it need not be completed before the TAP is accepted as "Draft". While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details. The final implementation must include test code and documentation appropriate for the TUF reference.
 
-9. *Copyright* -- Each TAP must either be explicitly labeled as placed in the public domain (see this TAP as an example) or licensed under the [Open Publication License](https://opencontent.org/openpub/).
+9. *Copyright* -- Each TAP must either be explicitly labeled as placed in the public domain (see this TAP as an example) or licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
 
 # TAP Formats and Templates
 

--- a/tap2.md
+++ b/tap2.md
@@ -43,4 +43,4 @@ The augmented reference implementation must be completed before any TAP is given
 
 # Copyright
 
-Each TAP must either be explicitly labeled as placed in the public domain (see this TAP as an example) or licensed under the [Open Publication License](https://opencontent.org/openpub/).
+Each TAP must either be explicitly labeled as placed in the public domain or licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).

--- a/tap2.md
+++ b/tap2.md
@@ -43,4 +43,4 @@ The augmented reference implementation must be completed before any TAP is given
 
 # Copyright
 
-Each TAP must either be explicitly labeled as placed in the public domain or licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+Each TAP must either be explicitly labeled as placed in the public domain (see TAP 1 as an example) or licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Per the discussion in #126, TAPs should be either placed in the public domain _or_ licensed under the Creative Commons Attribution 4.0 International License (CC-By). This PR updates tap1 & tap2 to remove references to the Open Publication License, and instead recommend CC-By for non-public domain TAPs.

Also fixup the comment in the tap1 dot file which suggests how to generate a png of the flow diagram.