### PR TITLE
Snapshot merkle POUF

### DIFF
--- a/POUFs/reference-POUF/pouf1.md
+++ b/POUFs/reference-POUF/pouf1.md
@@ -22,6 +22,8 @@ This POUF uses a subset of the JSON object format, with floating-point numbers o
 
 In this POUF, metadata files are hosted on the repository using HTTP. The filenames for these files are ROLE.json where ROLE is the associated role name (root, targets, snapshot, or timestamp). A client downloads these files by HTTP post request. The location of the repository is preloaded onto the clients.
 
+Snapshot Merkle trees in this implementation will use sha256 to compute the hash of each node.
+
 ## Message Handler Table
 
 This table lists the message handlers supported by the reference implementation.
@@ -336,6 +338,7 @@ The timestamp file is signed by a timestamp key.  It indicates the
          "spec_version" : SPEC_VERSION,
          "version" : VERSION,
          "expires" : EXPIRES,
+         ("merkle_root": ROOT_HASH),
          "meta" : METAFILES
        }
 
@@ -360,6 +363,8 @@ The timestamp file is signed by a timestamp key.  It indicates the
      the cryptographic hash function.  For example: { "sha256": HASH, ... }.
      HASH is the hexdigest of the cryptographic function computed on the
      snapshot.json metadata file.
+
+     ROOT_HASH is the hash of the Merkle tree's root node.
 
 ### mirrors.json
 The mirrors.json file is signed by the mirrors role.  It indicates which
@@ -399,6 +404,22 @@ mirror that will be used to download that file.  Successive mirrors with
 matching paths will only be tried if downloading from earlier mirrors fails.
 This behavior can be modified by the client code that uses the framework to,
 for example, randomly select from the listed mirrors.
+
+
+### Snapshot Merkle metadata
+
+Snapsot Merkle metadata is not signed. It lists version information for a metadata file, and a path through the Merkle tree to verify this information.
+
+```
+{ “leaf_contents”: {METAFILES},
+  “merkle_path”: {INDEX:HASH}
+  “path_directions”:{INDEX:DIR}
+}
+```
+
+Where `METAFILES` is the version information as defined for snapshot metadata,
+`INDEX` provides the ordering of nodes, `HASH` is the sha256 hash of the sibling node,
+and `DIR` is a `1` or `0` that indicates whether the given node is a left or right sibling.
 
 
 # Security Audit


### PR DESCRIPTION
Add description of snapshot Merkle metadata to the reference implementation POUF, based on the description of snapshot Merkle trees in #125.

This pr is a draft, and should be merged only if/when theupdateframework/tuf#1113 is incorporated into the reference implementation.