### PR TITLE
Update links for reference implementation rename

### DIFF
--- a/tap1.md
+++ b/tap1.md
@@ -158,7 +158,7 @@ TAPs MAY include auxiliary files such as diagrams. These files MUST be named ``t
 # Reporting TAP Bugs, or Submitting TAP Updates
 
 The procedure for reporting a bug, or submitting a TAP update depends on several factors, such as the maturity of the TAP, the preferences of the TAP author, and the nature of the comments.  For Draft or Accepted TAPs, feedback should be via the TAPs [issue tracker](https://github.com/theupdateframework/taps/issues) or as a pull request against the TAP in question.
-Once a TAP has been marked Final, bugs or corrections SHOULD be submitted to the TUF [issue tracker](https://github.com/theupdateframework/tuf/issues) so that changes do not get lost.
+Once a TAP has been marked Final, bugs or corrections SHOULD be submitted to the TUF [issue tracker](https://github.com/theupdateframework/specification/issues) so that changes do not get lost.
 
 # Transferring TAP Ownership
 

--- a/tap10.md
+++ b/tap10.md
@@ -135,7 +135,7 @@ of the *compressed_algorithms* attribute.
 
 # Augmented Reference Implementation
 
-Pull request [#485](https://github.com/theupdateframework/tuf/pull/485) removes native support for compressed metadata.
+Pull request [#485](https://github.com/theupdateframework/python-tuf/pull/485) removes native support for compressed metadata.
 
 # Copyright
 

--- a/tap14.md
+++ b/tap14.md
@@ -585,7 +585,7 @@ in the specification section.
 
 # Augmented Reference Implementation
 
-Semantic Versioning was added to the TUF Reference Implementation in [#914](https://github.com/theupdateframework/tuf/pull/914).
+Semantic Versioning was added to the TUF Reference Implementation in [#914](https://github.com/theupdateframework/python-tuf/pull/914).
 The rest of this proposal has not yet been implemented.
 
 # Copyright

--- a/tap16.md
+++ b/tap16.md
@@ -300,7 +300,7 @@ compatibility for clients and repositories.
 
 # Augmented Reference Implementation
 
-https://github.com/theupdateframework/tuf/pull/1113/
+https://github.com/theupdateframework/python-tuf/pull/1113/
 TODO: auditor implementation
 
 # Copyright

--- a/tap3.md
+++ b/tap3.md
@@ -70,7 +70,7 @@ file format of targets metadata.
 ## The previous file format of targets metadata
 
 In the [previous
-version](https://github.com/theupdateframework/tuf/blob/70fc8dce367cf09563915afa40cffee524f5b12b/docs/tuf-spec.txt#L766-L776)
+version](https://github.com/theupdateframework/python-tuf/blob/70fc8dce367cf09563915afa40cffee524f5b12b/docs/tuf-spec.txt#L766-L776)
 of the specification, each delegation could specify only a _single_ role as
 required to sign the given set of targets.
 

--- a/tap4.md
+++ b/tap4.md
@@ -291,7 +291,7 @@ A TUF repository does not need to change in any way to support this TAP.
 
 # Augmented Reference Implementation
 
-Pull Request [#504](https://github.com/theupdateframework/tuf/pull/504)
+Pull Request [#504](https://github.com/theupdateframework/python-tuf/pull/504)
 implements multiple repository consensus on entrusted targets via a map file.
 
 # Copyright

--- a/tap5.md
+++ b/tap5.md
@@ -60,7 +60,7 @@ files itself.
 In this manner, it can always serve the latest versions of metadata, instead of
 depending on the mirror, which may be more easily compromised, to do so.
 Unfortunately, there is no way to implement this use case using the
-[previous specification](https://github.com/theupdateframework/tuf/blob/70fc8dce367cf09563915afa40cffee524f5b12b/docs/tuf-spec.txt#L766-L776).
+[previous specification](https://github.com/theupdateframework/python-tuf/blob/70fc8dce367cf09563915afa40cffee524f5b12b/docs/tuf-spec.txt#L766-L776).
 
 PyPI can solve the problem, if it is somehow able to specify that the snapshot
 and targets metadata files should be downloaded from the mirror, but that the
@@ -83,7 +83,7 @@ to the root metadata file format.
 ## The previous root metadata file format
 
 In the
-[previous specification](https://github.com/theupdateframework/tuf/blob/70fc8dce367cf09563915afa40cffee524f5b12b/docs/tuf-spec.txt#L766-L776),
+[previous specification](https://github.com/theupdateframework/python-tuf/blob/70fc8dce367cf09563915afa40cffee524f5b12b/docs/tuf-spec.txt#L766-L776),
 there was no list of URLs associated with each top-level role.
 
 ```Javascript

--- a/tap6.md
+++ b/tap6.md
@@ -19,7 +19,7 @@ metadata.
 
 As the TUF specification evolves there are likely to be breaking changes.  For
 example, commit 5d2c8fdc7658a9f7648c38b0c79c0aa09d234fe2 in
-github.com/theupdateframework/tuf removes the "private" field, which would
+github.com/theupdateframework/python-tuf removes the "private" field, which would
 break key ID calculations for older clients. Specifying the specification
 version a repository is operating under allows clients to determine
 whether they are compatible, rather than breaking in undefined ways.
@@ -80,7 +80,7 @@ of concrete types with defined fields to parse retrieved metadata data.
 
 # Augmented Reference Implementation
 
-Pull request [#487](https://github.com/theupdateframework/tuf/pull/487) adds
+Pull request [#487](https://github.com/theupdateframework/python-tuf/pull/487) adds
 "spec_version" to metadata.
 
 # Copyright

--- a/tap7.md
+++ b/tap7.md
@@ -58,7 +58,7 @@ behavior as intended by the designers of TUF,
 and, most importantly, ensure that an updater is secure against
 the types of attacks and weaknesses listed in
 Section 1.5.2 of the
-[TUF Specification](https://github.com/theupdateframework/tuf/blob/develop/docs/tuf-spec.txt).
+[TUF Specification](https://theupdateframework.github.io/specification/latest/#goals-to-protect-against-specific-attacks).
 
 
 # Rationale
@@ -93,8 +93,8 @@ available so that anyone can use them to test their updater implementation.
 # Specification
 
 The client updater implementation to be tested should operate as described in
-the Client Workflow in Section 5.1 of the
-[TUF Specification](https://github.com/theupdateframework/tuf/blob/develop/docs/tuf-spec.txt).
+the Client Workflow in Section 5 of the
+[TUF Specification](https://theupdateframework.github.io/specification/latest/#detailed-client-workflow).
 Tests will verify this behavior, determining whether or not the updater defends
 against attacks described in Section 1.5.2 of the TUF Specification.
 

--- a/tap7.md
+++ b/tap7.md
@@ -18,7 +18,7 @@ specification.  At this point, no tool or set of data exists to help developers
 and users affirm
 that an implementation of an update system behaves according to the TUF
 specification. Although the reference implementation contains
-[unit tests](https://github.com/theupdateframework/tuf/tree/develop/tests)
+[unit tests](https://github.com/theupdateframework/python-tuf/tree/develop/tests)
 that verify correct behavior (such as updating metadata in the expected order
 and blocking known updater attacks) these unit tests only work within the
 parameters of the reference implementation. This is problematic due to the
@@ -106,7 +106,7 @@ Tests will attempt endless data attacks, indefinite freeze attacks, replay
 attacks, and a variety of others discussed in the TUF Specification. The full
 listing of conformance tests and expected results will be provided in
 documentation
-[alongside the TUF Specification](https://github.com/theupdateframework/tuf/blob/develop/docs).
+[alongside the TUF Specification](https://github.com/theupdateframework/python-tuf/blob/develop/docs).
 
 
 ## Test Case Elements
@@ -190,7 +190,7 @@ format.
 
 The format of this dictionary of keys represented in `keys.json` is as follows.
 (Note that the individual keys resemble ANYKEY_SCHEMA in the
-[TUF format definitions](https://github.com/theupdateframework/tuf/blob/develop/tuf/formats.py))
+[TUF format definitions](https://github.com/theupdateframework/python-tuf/blob/develop/tuf/formats.py))
   ```javascript
   {
     <rolename_1>: [ // This role should be signed by these two keys:

--- a/tap9.md
+++ b/tap9.md
@@ -11,7 +11,7 @@
 # Abstract
 
 This was started by the discussion about standardizing signatures in [this
-GitHub issue](https://github.com/theupdateframework/tuf/issues/425#issuecomment-300792546)
+GitHub issue](https://github.com/theupdateframework/python-tuf/issues/425#issuecomment-300792546)
 in the main TUF repository. Most of the information and arguments that arose
 from that discussion have been captured in this document.
 
@@ -378,7 +378,7 @@ the TAP would be fully implemented.
 
 The reference implementation incorporates TAP 9
 [here](https://github.com/secure-systems-lab/securesystemslib/pull/48) and
-[here](https://github.com/theupdateframework/tuf/pull/484).
+[here](https://github.com/theupdateframework/python-tuf/pull/484).
 
 # Copyright
 


### PR DESCRIPTION
We are planning to rename the reference implementation from tuf->python-tuf, this PR updates links to the reference implementation and should be merged after the change is made.

In this PR there is also:
1. a change to TAP-1 which points people filing bugs against Final TAPs to the specification's issue tracker, not the reference implementations
2. a change to TAP-7 to link to the rendered specification at https://theupdateframework.github.io/specification/latest/, not the old version in the reference implementation's git history