### PR TITLE
TAP-15: clarify all delegation attributes are optional

### DIFF
--- a/tap15.md
+++ b/tap15.md
@@ -177,12 +177,12 @@ With the addition of succinct hashed bins, the delegation will contain:
        ("name": ROLENAME,)
        "keyids" : [ KEYID, ... ] ,
        "threshold" : THRESHOLD,
-       ("path_hash_prefixes" : [ HEX_DIGEST, ... ] |
-       ("succinct_hash_delegations" : {
+       ("path_hash_prefixes" : [ HEX_DIGEST, ... ], |
+       "paths" : [ PATHPATTERN, ... ], |
+       "succinct_hash_delegations" : {
          "delegation_hash_prefix_len" : BIT_LENGTH,
          "bin_name_prefix" : NAME_PREFIX
        })
-        "paths" : [ PATHPATTERN, ... ]),
        "terminating": TERMINATING,
    }, ... ]
  }

--- a/tap15.md
+++ b/tap15.md
@@ -251,3 +251,7 @@ would happen if one or both of them supports succinct_hash_delegations.
 
 As you can see, if Alice supports succinct_hash_delegations and Bob
 does not, Bob will not be able to verify J.
+
+# Augmented Reference Implementation
+
+https://github.com/theupdateframework/python-tuf/pull/1106


### PR DESCRIPTION
The "succinct_hash_delegations" attribute was missing an or symbol ('|')
between it and the "paths" attribute. This patch re-orders the optional
delegation attributes, sorting them alphabetically (with the happy outcome
that the more complex optional attribute comes last), and ensure's there's
an or symbol ('|') separating each optional attribute.

Signed-off-by: Joshua Lock <jlock@vmware.com>