### PR TITLE
Add augmented reference implementation of TAP 12

### DIFF
--- a/tap12.md
+++ b/tap12.md
@@ -272,7 +272,7 @@ SHA2-256 to calculate keyids.
 
 # Augmented Reference Implementation
 
-TODO
+[python-tuf 1.0](https://github.com/theupdateframework/python-tuf/releases/tag/v1.0.0) does not calculate keyids using the hash algorithm.
 
 # Copyright
 


### PR DESCRIPTION
[python-tuf 1.0](https://github.com/theupdateframework/python-tuf/releases/tag/v1.0.0) lets keyids be arbitrary strings as described in this TAP (discussed in theupdateframework/python-tuf#1084). As such, it can be used as an implementation of this TAP.

With this, are there any blockers to moving this TAP to accepted?