### PR TITLE
Re-design TAP 15 metadata format

### DIFF
--- a/tap15.md
+++ b/tap15.md
@@ -128,7 +128,7 @@ that includes the following:
 "succinct_roles" : {
        "keyids" : [ KEYID, ... ] ,
        "threshold" : THRESHOLD,
-       "prefix_bit_length": BIT_LENGTH,
+       "bit_length": BIT_LENGTH,
        "name_prefix": NAME_PREFIX,
    }
 
@@ -192,7 +192,7 @@ With the addition of succinct hashed bins, the delegation will contain:
   "succinct_roles" : {
          "keyids" : [ KEYID, ... ] ,
          "threshold" : THRESHOLD,
-         "prefix_bit_length": BIT_LENGTH,
+         "bit_length": BIT_LENGTH,
          "name_prefix": NAME_PREFIX,
      },
 }
@@ -210,7 +210,7 @@ With the addition of succinct hashed bins, the delegation will contain:
     "succinct_roles" : {
         "keyids" : [ abc123 ] ,
         "threshold" : 1,
-        "prefix_bit_length": 16,
+        "bit_length": 16,
         "name_prefix" : "alice.hbd-",
     },
   }

--- a/tap15.md
+++ b/tap15.md
@@ -186,7 +186,7 @@ With the addition of succinct hashed bins, the delegation will contain:
       KEYID : KEY,
       ...
   },
-  "roles" : [
+  ("roles" : [
     {
       "name": ROLENAME,
       "keyids" : [ KEYID, ... ] ,
@@ -196,13 +196,13 @@ With the addition of succinct hashed bins, the delegation will contain:
       "terminating": TERMINATING,
     },
     ...
-  ],
-  "succinct_roles" : {
+  ],)
+  ("succinct_roles" : {
          "keyids" : [ KEYID, ... ] ,
          "threshold" : THRESHOLD,
          "bit_length": BIT_LENGTH,
          "name_prefix": NAME_PREFIX,
-     },
+     },)
 }
  ```
 

--- a/tap15.md
+++ b/tap15.md
@@ -142,7 +142,9 @@ previous delegations.
 
 When a delegation contains this field, it represents delegations to
 2^BIT_LENGTH bins that use the included keyids and threshold. All
-succinct hashed bin delegations will be non-terminating. The
+succinct hashed bin delegations will be non-terminating. If a user
+would like succinct delegations to be terminating, they may add the
+terminating flag in either the parent delegation or in the individual bins. The
 path_hash_prefixes and name for each
 bin will be determined using the BIT_LENGTH and NAME_PREFIX.
 

--- a/tap15.md
+++ b/tap15.md
@@ -161,7 +161,7 @@ The rolename of each bin will be determined by the bin number and the
 NAME_PREFIX listed in the `name_prefix` field of the delegation.
 The name will be structured as
 NAME_PREFIX-COUNT where COUNT is a hexadecimal value between 0 and
-2^BIT_LENGTH-1 (inclusive) that represents the bin number.
+2^BIT_LENGTH-1 (inclusive) that represents the bin number. This value will be zero-padded so that all rolenames will be of the same length.
 
 Only one of `succinct_roles` or `roles` may be specified in a
 delegation. If a role A would like to delegate to both `succinct_roles`
@@ -221,6 +221,8 @@ With the addition of succinct hashed bins, the delegation will contain:
     },
   }
  </code></pre>
+
+ The associated bins will be named `alice.hbd-0000`, `alice.hbd-0001`, ... `alice.hbd-FFFF`.
 
 # Security Analysis
 

--- a/tap15.md
+++ b/tap15.md
@@ -194,8 +194,8 @@ With the addition of succinct hashed bins, the delegation will contain:
       "terminating": TERMINATING,
     },
     ...
-  ],) |
-  ("succinct_roles" : {
+  ], |
+  "succinct_roles" : {
          "keyids" : [ KEYID, ... ] ,
          "threshold" : THRESHOLD,
          "bit_length": BIT_LENGTH,

--- a/tap15.md
+++ b/tap15.md
@@ -164,7 +164,7 @@ NAME_PREFIX-COUNT where COUNT is a hexadecimal value between 0 and
 2^BIT_LENGTH-1 (inclusive) that represents the bin number.
 
 Only one of `succinct_roles` or `roles` may be specified in a
-delegation.
+delegation. If a role A would like to delegate to both `succinct_roles` S and `roles` R, they may do so through the use of intermediate delegations. A would create namespaced delegations to both B and C. B would then delegate to S using `succinct_roles`, and C would delegate to R using `roles`. An advantage to this approach is that A may decide which of S or R should be prioritized for each package through the ordering of the delegations to B and C.
 
 If a delegation contains a succinct hash delegation, all metadata
 files represented by this delegation must exist on the repository,

--- a/tap15.md
+++ b/tap15.md
@@ -141,7 +141,7 @@ KEYID and THRESHOLD have the same definitions as in
 previous delegations.
 
 When a delegation contains this field, it represents delegations to
-2^BIT_LENGTH bins that use the included keyids and threshold. All
+2^BIT_LENGTH bins which all use the specified keyids and threshold. All
 succinct hashed bin delegations will be non-terminating. If a user
 would like succinct delegations to be terminating, they may add the
 terminating flag in either the parent delegation or in the individual bins.
@@ -194,7 +194,7 @@ With the addition of succinct hashed bins, the delegation will contain:
       "terminating": TERMINATING,
     },
     ...
-  ],)
+  ],) |
   ("succinct_roles" : {
          "keyids" : [ KEYID, ... ] ,
          "threshold" : THRESHOLD,

--- a/tap15.md
+++ b/tap15.md
@@ -166,7 +166,13 @@ NAME_PREFIX-COUNT where COUNT is a hexadecimal value between 0 and
 2^BIT_LENGTH-1 (inclusive) that represents the bin number.
 
 Only one of `succinct_roles` or `roles` may be specified in a
-delegation. If a role A would like to delegate to both `succinct_roles` S and `roles` R, they may do so through the use of intermediate delegations. A would create namespaced delegations to both B and C. B would then delegate to S using `succinct_roles`, and C would delegate to R using `roles`. An advantage to this approach is that A may decide which of S or R should be prioritized for each package through the ordering of the delegations to B and C.
+delegation. If a role A would like to delegate to both `succinct_roles`
+S and `roles` R (or to a second succinct role), they may do so through
+the use of intermediate delegations. A would create namespaced
+delegations to both B and C. B would then delegate to S using
+`succinct_roles`, and C would delegate to R using `roles`. An advantage
+to this approach is that A may decide which of S or R should be
+prioritized for each package through the ordering of the delegations to B and C.
 
 If a delegation contains a succinct hash delegation, all metadata
 files represented by this delegation must exist on the repository,

--- a/tap15.md
+++ b/tap15.md
@@ -142,7 +142,7 @@ previous delegations.
 
 When a delegation contains this field, it represents delegations to
 2^BIT_LENGTH bins that use the included keyids and threshold. All
-succinct hashed bin delegations will be terminating. The
+succinct hashed bin delegations will be non-terminating. The
 path_hash_prefixes and name for each
 bin will be determined using the BIT_LENGTH and NAME_PREFIX.
 

--- a/tap15.md
+++ b/tap15.md
@@ -144,9 +144,7 @@ When a delegation contains this field, it represents delegations to
 2^BIT_LENGTH bins that use the included keyids and threshold. All
 succinct hashed bin delegations will be non-terminating. If a user
 would like succinct delegations to be terminating, they may add the
-terminating flag in either the parent delegation or in the individual bins. The
-path_hash_prefixes and name for each
-bin will be determined using the BIT_LENGTH and NAME_PREFIX.
+terminating flag in either the parent delegation or in the individual bins.
 
 As in the current use of hashed bin delegations, target files will be
 distributed to bins based on the SHA2-256 hash of the target path and


### PR DESCRIPTION
Address some discussion from #132 by moving succinct hashed bin delegations to a new object within delegations.

In this version I opted to keep `path_hash_prefixes`, although I added a note that this field may be removed later backwards-incompatible way.

For simplicity, this change states that only one of `succinct_roles` or `roles` may be included. This seems to cover the most common use cases. Users with less common use cases could set up a complicated delegation tree if they would like to combine namespaced delegations and succinct hashed bin delegations, but it can't be done in the same delegation.

cc @jku @MVrachev @JustinCappos @trishankatdatadog @lukpueh 