### PR TITLE
Tap14 updates

### DIFF
--- a/tap14.md
+++ b/tap14.md
@@ -163,7 +163,7 @@ with a directory for each supported TUF specification version. These directories
 contain metadata that supports the given TUF specification version. Using these
 directories, a client is able to choose the most recent metadata they support.
 More details about this directory structure are contained in the [specification](#how-a-repository-updates).
-This TAP will also add a `supported-versions` field to root metadata so that the client
+This TAP will also add a `supported_versions` field to root metadata so that the client
 can discover the supported specification versions on the repository.
 
 On the client side, this TAP also requires maintenance of multiple versions that
@@ -250,7 +250,7 @@ has been updated to include the TUF Version field.
 
 Repositories will add two things. They MUST put metadata for new TUF
 specification versions in new
-directories. In addition, root metadata on a repository SHOULD add a `supported-versions` field
+directories. In addition, root metadata on a repository SHOULD add a `supported_versions` field
 to indicate which specification versions are supported.
 
 As described in the [Rationale](#rationale), repositories should support multiple
@@ -370,7 +370,7 @@ upgrades from version 1.x.y to version 2.0.0 may look like:
 Not all TUF repositories have a mechanism that is able to list all directories
 in a folder (the equivalent of the `ls` command). For these repositories (such
 as OCI registries or http servers), as well as to prevent specification version
-freeze attacks, root metadata SHOULD include a `supported-versions` field that lists
+freeze attacks, root metadata SHOULD include a `supported_versions` field that lists
 all versions supported by the repository to allow for client discovery. As it is
 included in root metadata, this field will be signed by a threshold of root keys,
 and will contain the following fields:
@@ -431,7 +431,7 @@ following procedure:
 
 * The client determines the latest version available on the repository by
 looking for the directory with the largest version number, or by parsing the
-`supported-versions` field in root metadata.
+`supported_versions` field in root metadata.
 * If the latest version on the repository is lower than the previous
 specification version the client used from this repository, the client
 should report an error and terminate the update.
@@ -565,7 +565,7 @@ A downgrade attack on the TUF specification version may be possible if an
 attacker is able to block access to a directory on the repository. This would
 mean that a client would use metadata from a previous specification version when
 performing an update.
-However, a client would be able to detect this attack using the `supported-versions`
+However, a client would be able to detect this attack using the `supported_versions`
 field listed in root metadata and signed with root keys.
 
 Clients that have previously used a repository will store the specification

--- a/tap14.md
+++ b/tap14.md
@@ -190,7 +190,7 @@ metadata files while allowing flexibility in how repositories and delegations
 are managed.
 
 For example, during the course of an update a client could use 4.0.0_parse_root,
-4.0.0_parse_snapshot, 4.0.0_parse_timestamp, 4.0.0_parse_targets,
+4.0.0_parse_timestamp, 4.0.0_parse_snapshot, 4.0.0_parse_targets,
 4.0.0_parse_delegation, and 3.0.0_parse_delegation.
 
 

--- a/tap14.md
+++ b/tap14.md
@@ -478,25 +478,25 @@ provided by each repository. Note that different TUF versions may use different
 hashing algorithms. If this is the case, both hashes should be verified
 independently.
 
-### TAP 5
+### TAP 13
 
-A TUF client that supports TAP 5 may download top-level metadata from multiple
-sources. However, breaking changes may require that multiple top-level metadata
-files use the same TUF specification version. To manage this, a root metadata
-file that includes a list of urls for metadata as described in TAP 5 should
-only include links to metadata files using the same TUF specification version as
-the root metadata file.
+A TUF client that supports TAP 13 may download targets metadata from multiple
+sources. However, breaking changes may require that all top-level metadata
+files use the same TUF specification version. To manage this, a client
+configuration file that lists a custom top-level targets metadata file
+as described in TAP 13 should only include targets metadata files using the
+same TUF specification version as the root metadata file.
 
-The owner of root metadata is responsible for ensuring that all metadata files
-linked in the root metadata use the same TUF specification version as the root
+The owner of the client configuration is responsible for ensuring that any
+custom targets metadata files use the same TUF specification version as the root
 metadata. If the repository that contains the root metadata supports multiple
-TUF specification versions, each root metadata file should list top-level
-metadata corresponding with its TUF specification version.
+TUF specification versions, the client configuration should list a targets metadata
+file that is available in all supported specification versions.
 
 Clients should verify that all top-level metadata use the same TUF specification
-version as the root metadata. If a metadata file linked in root metadata does
-not meet this criteria, it will be considered invalid and the client should
-use the next listed metadata file or terminate the update.
+version as the root metadata. If a metadata file provided by the TAP 13 configuration
+does not meet this criteria, it will be considered invalid and the client should
+terminate the update.
 
 ### Delegations
 

--- a/tap14.md
+++ b/tap14.md
@@ -248,8 +248,10 @@ has been updated to include the TUF Version field.
 
 ## How a repository updates
 
-Repositories will add metadata for new TUF specification versions in new
-directories and SHOULD maintain a `supported-versions` file.
+Repositories will add two things. They MUST put metadata for new TUF
+specification versions in new
+directories. In addition, repositories SHOULD maintain a `supported-versions` file
+to indicate which specification versions are supported.
 
 As described in the [Rationale](#rationale), repositories should support multiple
 TUF specification versions. In order to do so, this TAP proposes a new directory
@@ -368,16 +370,23 @@ upgrades from version 1.x.x to version 2.0.0 may look like:
 Not all TUF repositories have a mechanism that is  able to list all directories
 in a folder (the equivalent of the `ls` command). For these repositories (such
 as OCI registries or http servers), the repository SHOULD include a
-`supported-versions` file in the top of this directory structure that lists
+`supported-versions.json` file in the top of this directory structure that lists
 all versions supported by the repository to allow for client discovery. This file
-will have the following fields:
+will be signed by a threshold of root keys, and the `signed` portion will have
+the following fields:
 
 ```
-{ "supported_versions" : [VERSION, ...],
+{ "supported_versions" : [
+    { MAJOR_VERSION: FOLDER_NAME},
+    ...
+  ]
+}
 
 ```
 
-where `VERSION` is the integer name of a supported major version (i.e. 2).
+where `MAJOR_VERSION` is the integer representing a supported major version (i.e. 2)
+and `FOLDER_NAME` is the integer representing the folder containing metadata for
+this supported major version. In most cases, `MAJOR_VERSION` should match `FOLDER_NAME`.
 For backwards compatability, version 1 should be assumed to be in the top-level
 repository with no directory named 1.
 

--- a/tap14.md
+++ b/tap14.md
@@ -377,16 +377,19 @@ the following fields:
 
 ```
 { "supported_versions" : [
-    { MAJOR_VERSION: FOLDER_NAME},
+    { "version": MAJOR_VERSION,
+      "path": FOLDER_NAME},
     ...
   ]
 }
 
 ```
 
-where `MAJOR_VERSION` is the integer representing a supported major version (i.e. 2)
+where `MAJOR_VERSION` is the integer representing a supported major version
 and `FOLDER_NAME` is the string representing the folder containing metadata for
-this supported major version. In most cases, `MAJOR_VERSION` should match `FOLDER_NAME`.
+this supported major version (e.g. { "version": 2, "path": "2" }).
+`FOLDER_NAME` MUST NOT contain any subdirectories.
+In most cases, `MAJOR_VERSION` should match `FOLDER_NAME`.
 For backwards compatability, version 1 should be assumed to be in the top-level
 repository with no directory named 1.
 

--- a/tap14.md
+++ b/tap14.md
@@ -163,7 +163,7 @@ with a directory for each supported TUF specification version. These directories
 contain metadata that supports the given TUF specification version. Using these
 directories, a client is able to choose the most recent metadata they support.
 More details about this directory structure are contained in the [specification](#how-a-repository-updates).
-The repository may also maintain a `supported-version` file so that the client
+The repository may also maintain a `supported-versions` file so that the client
 can discover the supported specification versions on the repository.
 
 On the client side, this TAP also requires maintenance of multiple versions that
@@ -180,7 +180,7 @@ version. A specification change may rely on more than one metadata file (for
 example a change in the signing process would affect all metadata types), so
 using the same specification version for top-level metadata allows for these
 large changes to the specification. For information about how this relates to
-targets metadta pinning and TAP 13, see [Special Cases](#tap-13). However,
+targets metadata pinning and TAP 13, see [Special Cases](#tap-13). However,
 delegated targets metadata may not be
 managed by the same parties as the top-level metadata. For this reason, this TAP
 allows clients to use a different TUF specification version for delegated
@@ -365,9 +365,9 @@ upgrades from version 1.0.0 to version 2.0.0 may look like:
   |- 2.0.0 metadata files
 ```
 
-Not all TUF repositories have file systems that are able to list all directories
+Not all TUF repositories have a mechanism that is  able to list all directories
 in a folder (the equivalent of the `ls` command). For these repositories (such
-as OCI registries or html servers), the repository SHOULD include a
+as OCI registries or http servers), the repository SHOULD include a
 `supported-versions` file in the top of this directory structure that lists
 all versions supported by the repository to allow for client discovery. This file
 will have the following fields:
@@ -499,8 +499,9 @@ independently.
 
 ### TAP 13
 
-A TUF client that supports TAP 13 may download targets metadata from multiple
-sources. However, breaking changes may require that all top-level metadata
+A TUF client that supports TAP 13 may download targets metadata that were
+uploaded by different parties.
+However, breaking changes may require that all top-level metadata
 files use the same TUF specification version. To manage this, a client
 configuration file that lists a custom top-level targets metadata file
 as described in TAP 13 should only include targets metadata files using the

--- a/tap14.md
+++ b/tap14.md
@@ -255,7 +255,7 @@ As described in the [Rationale](#rationale), repositories should support multipl
 TUF specification versions. In order to do so, this TAP proposes a new directory
 structure for repositories. When a repository manager chooses to upgrade to a
 new major TUF specification version, they create a new directory on the repository named
-for the major version (for example 2.0.0). This directory will contain all
+for the major version (for example 2). This directory will contain all
 metadata files for the new specification version, but target files will remain in the
 parent directory to save space. In this case the metadata files (in directories according to their spec
 version) can point to target files relative to the parent directory. After creating
@@ -270,16 +270,16 @@ version 2.0.0, the repository structure may look like:
 
 ```
 - Target files
-- 1.0.0
+- 1
   |- metadata files
-- 2.0.0
+- 2
   |- metadata files
 ```
 
 Repository updates to a new minor or patch specification version shall be done
 by uploading new metadata files in the new format to the proper directory. So if
 a repository updates from 2.0.0 to 2.1.0, the 2.1.0 metadata would go in the
-directory named 2.0.0. Minor and patch version changes are backwards compatible,
+directory named 2. Minor and patch version changes are backwards compatible,
 so clients using version 2.0.0 will still be able to parse metadata written
 using version 2.1.0.
 
@@ -346,23 +346,23 @@ TUF versions that the repository supports. Any update should be reflected across
 all of these versions. For clarity, version numbers used for consistent
 snapshots should be consistent across all
 supported specification versions so that a client can find the current
-metadata files. This means that there may be a file at 1.0.0/3.root.json as well
-as 2.0.0/3.root.json. Root metadata files with the same consistent snapshot number must
+metadata files. This means that there may be a file at 1/3.root.json as well
+as 2/3.root.json. Root metadata files with the same consistent snapshot number must
 also use the same keys so that a client can find the next root metadata file in whichever
 specification version they support.
 
 For existing TUF clients to continue operation after this TAP is implemented,
 repositories may store metadata from before TUF 2.0.0 in the top-level
-repository (with no directory named 1.0.0). This allows existing clients to
+repository (with no directory named 1). This allows existing clients to
 continue downloading metadata from the repository. So a TUF repository that
-upgrades from version 1.0.0 to version 2.0.0 may look like:
+upgrades from version 1.x.x to version 2.0.0 may look like:
 
 
 ```
 - Targets files
-- 1.0.0 metadata files
-- 2.0.0
-  |- 2.0.0 metadata files
+- 1.x.x metadata files
+- 2
+  |- 2.x.x metadata files
 ```
 
 Not all TUF repositories have a mechanism that is  able to list all directories
@@ -377,7 +377,7 @@ will have the following fields:
 
 ```
 
-where `VERSION` is the name of a supported version in the format `version-number.0.0` (i.e. 2.0.0).
+where `VERSION` is the name of a supported major version (i.e. 2).
 
 ## Changes to TUF clients
 
@@ -437,13 +437,13 @@ Once the supported directory is determined, the client shall attempt the update
 using the metadata in this directory.
 
 For example, if a client has a specification version of 3.5 and a repository has
-directories for 2.0.0, 3.0.0, and 4.0.0, the client will report that spec
-version 4.x is available, then download metadata from the 3.0.0 directory. This reporting is
+directories for 2, 3, and 4, the client will report that spec
+version 4.x is available, then download metadata from the 3 directory. This reporting is
 up to the discretion of an implementer, but it should be used to encourage
 updating the client to the most recent specification version.
 
 Alternatively, if the same client downloads metadata from a repository with
-directories 1.0.0 and 2.0.0, the client could download metadata from 2.0.0 using
+directories 1 and 2, the client could download metadata from 2 using
 a 2.x version of the client. If 2.x is not supported by the client, the client
 will report that it is unable to perform an update.
 
@@ -460,7 +460,7 @@ major version of the root file.
 
 So, if the currently trusted root file is named 4.root.json and uses version
 1.0.0 and the highest supported version is 3.0.0, the client will look for
-5.root.json first in 3.0.0, then 2.0.0, then 1.0.0. If this file is found, the
+5.root.json first in 3, then 2, then 1. If this file is found, the
 client will look for 6.root.json using the same process. To facilitate this, the
 client should maintain functions to parse root files from previous spec
 versions. If the client does not support the specification version of a root file, the

--- a/tap14.md
+++ b/tap14.md
@@ -163,7 +163,7 @@ with a directory for each supported TUF specification version. These directories
 contain metadata that supports the given TUF specification version. Using these
 directories, a client is able to choose the most recent metadata they support.
 More details about this directory structure are contained in the [specification](#how-a-repository-updates).
-The repository may also maintain a `supported-versions.json` file so that the client
+This TAP will also add a `supported-versions` field to root metadata so that the client
 can discover the supported specification versions on the repository.
 
 On the client side, this TAP also requires maintenance of multiple versions that
@@ -250,7 +250,7 @@ has been updated to include the TUF Version field.
 
 Repositories will add two things. They MUST put metadata for new TUF
 specification versions in new
-directories. In addition, repositories SHOULD maintain a `supported-versions.json` file
+directories. In addition, root metadata on a repository SHOULD add a `supported-versions` field
 to indicate which specification versions are supported.
 
 As described in the [Rationale](#rationale), repositories should support multiple
@@ -369,14 +369,15 @@ upgrades from version 1.x.y to version 2.0.0 may look like:
 
 Not all TUF repositories have a mechanism that is able to list all directories
 in a folder (the equivalent of the `ls` command). For these repositories (such
-as OCI registries or http servers), the repository SHOULD include a
-`supported-versions.json` file in the top of this directory structure that lists
-all versions supported by the repository to allow for client discovery. This file
-will be signed by a threshold of root keys, and the `signed` portion will have
-the following fields:
+as OCI registries or http servers), as well as to prevent specification version
+freeze attacks, root metadata SHOULD include a `supported-versions` field that lists
+all versions supported by the repository to allow for client discovery. As it is
+included in root metadata, this field will be signed by a threshold of root keys,
+and will contain the following fields:
 
 ```
-{ "supported_versions" : [
+{ ...,
+  "supported_versions" : [
     { "version": MAJOR_VERSION,
       "path": FOLDER_NAME},
     ...
@@ -430,7 +431,7 @@ following procedure:
 
 * The client determines the latest version available on the repository by
 looking for the directory with the largest version number, or by parsing the
-`supported-versions.json` file.
+`supported-versions` field in root metadata.
 * If the latest version on the repository is lower than the previous
 specification version the client used from this repository, the client
 should report an error and terminate the update.
@@ -563,10 +564,9 @@ attacks and changes to the security model that should be discussed.
 A downgrade attack on the TUF specification version may be possible if an
 attacker is able to block access to a directory on the repository. This would
 mean that a client would use metadata from a previous specification version when
-performing an update. Similarly, an attacker on the repository could replace the
-`supported-versions.json` file to remove the most recent specification version.
-However, in both of these cases the metadata would still have to be current and
-properly signed.
+performing an update.
+However, a client would be able to detect this attack using the `supported-versions`
+field listed in root metadata and signed with root keys.
 
 Clients that have previously used a repository will store the specification
 version used to communicate with that repository, so a downgrade attack will

--- a/tap14.md
+++ b/tap14.md
@@ -163,7 +163,7 @@ with a directory for each supported TUF specification version. These directories
 contain metadata that supports the given TUF specification version. Using these
 directories, a client is able to choose the most recent metadata they support.
 More details about this directory structure are contained in the [specification](#how-a-repository-updates).
-The repository may also maintain a `supported-versions` file so that the client
+The repository may also maintain a `supported-versions.json` file so that the client
 can discover the supported specification versions on the repository.
 
 On the client side, this TAP also requires maintenance of multiple versions that
@@ -250,7 +250,7 @@ has been updated to include the TUF Version field.
 
 Repositories will add two things. They MUST put metadata for new TUF
 specification versions in new
-directories. In addition, repositories SHOULD maintain a `supported-versions` file
+directories. In addition, repositories SHOULD maintain a `supported-versions.json` file
 to indicate which specification versions are supported.
 
 As described in the [Rationale](#rationale), repositories should support multiple
@@ -385,7 +385,7 @@ the following fields:
 ```
 
 where `MAJOR_VERSION` is the integer representing a supported major version (i.e. 2)
-and `FOLDER_NAME` is the integer representing the folder containing metadata for
+and `FOLDER_NAME` is the string representing the folder containing metadata for
 this supported major version. In most cases, `MAJOR_VERSION` should match `FOLDER_NAME`.
 For backwards compatability, version 1 should be assumed to be in the top-level
 repository with no directory named 1.
@@ -427,7 +427,7 @@ following procedure:
 
 * The client determines the latest version available on the repository by
 looking for the directory with the largest version number, or by parsing the
-`supported-versions` file.
+`supported-versions.json` file.
 * If the latest version on the repository is lower than the previous
 specification version the client used from this repository, the client
 should report an error and terminate the update.
@@ -561,7 +561,7 @@ A downgrade attack on the TUF specification version may be possible if an
 attacker is able to block access to a directory on the repository. This would
 mean that a client would use metadata from a previous specification version when
 performing an update. Similarly, an attacker on the repository could replace the
-`supported-versions` file to remove the most recent specification version.
+`supported-versions.json` file to remove the most recent specification version.
 However, in both of these cases the metadata would still have to be current and
 properly signed.
 

--- a/tap14.md
+++ b/tap14.md
@@ -357,17 +357,17 @@ For existing TUF clients to continue operation after this TAP is implemented,
 repositories may store metadata from before TUF 2.0.0 in the top-level
 repository (with no directory named 1). This allows existing clients to
 continue downloading metadata from the repository. So a TUF repository that
-upgrades from version 1.x.x to version 2.0.0 may look like:
+upgrades from version 1.x.y to version 2.0.0 may look like:
 
 
 ```
 - Targets files
-- 1.x.x metadata files
+- 1.x.y metadata files
 - 2
-  |- 2.x.x metadata files
+  |- 2.x.y metadata files
 ```
 
-Not all TUF repositories have a mechanism that is  able to list all directories
+Not all TUF repositories have a mechanism that is able to list all directories
 in a folder (the equivalent of the `ls` command). For these repositories (such
 as OCI registries or http servers), the repository SHOULD include a
 `supported-versions.json` file in the top of this directory structure that lists

--- a/tap14.md
+++ b/tap14.md
@@ -377,7 +377,9 @@ will have the following fields:
 
 ```
 
-where `VERSION` is the name of a supported major version (i.e. 2).
+where `VERSION` is the integer name of a supported major version (i.e. 2).
+For backwards compatability, version 1 should be assumed to be in the top-level
+repository with no directory named 1.
 
 ## Changes to TUF clients
 

--- a/tap14.md
+++ b/tap14.md
@@ -478,7 +478,9 @@ So, if the currently trusted root file is named 4.root.json and uses version
 5.root.json first in 3, then 2, then 1. If this file is found, the
 client will look for 6.root.json using the same process. To facilitate this, the
 client should maintain functions to parse root files from previous spec
-versions. If the client does not support the specification version of a root file, the
+versions. Note that the library that supports a given spec version may also use
+a different naming convention than VERSION.root.json to find the root metadata.
+If the client does not support the specification version of a root file, the
 client shall terminate the update and report the specification version mismatch.
 
 When a client validates root and targets metadata, they may check for the

--- a/tap14.md
+++ b/tap14.md
@@ -181,7 +181,7 @@ example a change in the signing process would affect all metadata types), so
 using the same specification version for top-level metadata allows for these
 large changes to the specification. For information about how this relates to
 targets metadata pinning and TAP 13, see [Special Cases](#tap-13). However,
-delegated targets metadata may not be
+delegated targets metadata might not be
 managed by the same parties as the top-level metadata. For this reason, this TAP
 allows clients to use a different TUF specification version for delegated
 targets by maintaining functions to parse metadata that conforms to different
@@ -249,7 +249,7 @@ has been updated to include the TUF Version field.
 ## How a repository updates
 
 Repositories will add metadata for new TUF specification versions in new
-directories and may maintain a `supported-versions` file.
+directories and SHOULD maintain a `supported-versions` file.
 
 As described in the [Rationale](#rationale), repositories should support multiple
 TUF specification versions. In order to do so, this TAP proposes a new directory
@@ -439,7 +439,7 @@ using the metadata in this directory.
 For example, if a client has a specification version of 3.5 and a repository has
 directories for 2, 3, and 4, the client will report that spec
 version 4.x is available, then download metadata from the 3 directory. This reporting is
-up to the discretion of an implementer, but it should be used to encourage
+up to the discretion of each application, but it should be used to encourage
 updating the client to the most recent specification version.
 
 Alternatively, if the same client downloads metadata from a repository with

--- a/tap14.md
+++ b/tap14.md
@@ -303,9 +303,9 @@ maintained. Inclusion of this field will signal to clients both that they will
 need to upgrade to the next specification version before the timestamp, and
 that there will not be metadata available in the current directory after this
 point. The client can check the `becomes_obsolete` field in root metadata
-before checking the metadata expiration. This allows them to differentiate
-between metadata that is expired due to deprecation and metadata that is expired
-due to an attack. Delegated targets may include this field independent of
+before checking the metadata expiration. This allows them to differentiate between metadata
+that is expired due to intended deprecation, and metadata that is expired, e.g. because
+an attacker blocked the update. Delegated targets may include this field independent of
 top-level metadata to indicate when the metadata they are responsible for will
 no longer support a given TUF specification version. With the addition of this
 field, the "signed" portion of targets metadata will include the following:

--- a/tap14.md
+++ b/tap14.md
@@ -225,7 +225,7 @@ and so clients and repositories need to use code that supports the same major
 version when performing an update in order to maintain security and functionality.
 
 If the change adds a new feature that is backwards compatible, for example in
-TAP 4 and TAP 10, it should be part of a new minor version. These TAPs add
+TAP 4, it should be part of a new minor version. These TAPs add
 additional features to TUF, but clients that do not have these features will
 still be able to securely and reliably perform updates from repositories that
 support the TAPs. There may be minor differences as to which updates a client


### PR DESCRIPTION
I updated TAP 14 based on some implementation questions from @abs007.

This replaces references to the now-rejected TAP 5 with TAP 13 and adds a new optional file to support a range of filesystem types.