### PR TITLE
Update the list of referenced implementations for TAP 4

### DIFF
--- a/tap4.md
+++ b/tap4.md
@@ -290,8 +290,12 @@ A TUF repository does not need to change in any way to support this TAP.
 
 # Augmented Reference Implementation
 
-Pull Request [#504](https://github.com/theupdateframework/python-tuf/pull/504)
-implements multiple repository consensus on entrusted targets via a map file.
+There's an implementation of TAP 4 under the `multirepo` package in 
+[rdimitrov/go-tuf-metadata](https://github.com/rdimitrov/go-tuf-metadata).
+It implements the multiple repository consensus on entrusted targets via a
+map.json file. The package provides a multi-repository client API for creating
+a client, searching for a given target and downloading it all by implementing
+the search algorithm described in TAP 4.
 
 # Copyright
 

--- a/tap4.md
+++ b/tap4.md
@@ -294,7 +294,7 @@ There's an implementation of TAP 4 under the `multirepo` package in
 [rdimitrov/go-tuf-metadata](https://github.com/rdimitrov/go-tuf-metadata).
 It implements the multiple repository consensus on entrusted targets via a
 map.json file. The package provides a multi-repository client API for creating
-a client, searching for a given target and downloading it all by implementing
+a client, searching for a given target and downloading it all by following
 the search algorithm described in TAP 4.
 
 # Copyright


### PR DESCRIPTION
The following PR updates the list of referenced implementations for TAP 4

Details:

* deletes the old entry for python-tuf as this is no longer applicable
* adds rdimitrov/go-tuf-metadata